### PR TITLE
Use System.Xml for reading XML instead of Godot's XMLParser.

### DIFF
--- a/game/Game.tscn
+++ b/game/Game.tscn
@@ -6,7 +6,7 @@
 [ext_resource path="res://interface/Interface.tscn" type="PackedScene" id=4]
 [ext_resource path="res://interface/WesnothCamera.cs" type="Script" id=5]
 
-[node name="Game" type="Node2D"]
+[node name="Game" type="Node2D" index="0"]
 
 script = ExtResource( 1 )
 _sections_unfolded = [ "Cell", "Transform" ]

--- a/haldric.csproj
+++ b/haldric.csproj
@@ -47,6 +47,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="game\Game.cs" />

--- a/units/Unit.cs
+++ b/units/Unit.cs
@@ -1,10 +1,11 @@
 using Godot;
 using System;
+using System.Xml;
 
 public class Unit : Sprite
 {
 	Lifebar lifebar;
-	private System.Collections.Generic.Dictionary<String, String> attributes = new System.Collections.Generic.Dictionary<String, String>();
+	private XmlDocument attributes;
 
 	private int side;
 
@@ -19,9 +20,9 @@ public class Unit : Sprite
 
 	public override void _Ready()
 	{
-		damage = int.Parse(attributes["damage"]);
-		currentHealth = int.Parse(attributes["hitpoints"]);
-		currentMoves = int.Parse(attributes["movement"]);
+		damage = int.Parse(attributes.SelectSingleNode("/unit_type/damage").InnerText);
+		currentHealth = int.Parse(attributes.SelectSingleNode("/unit_type/hitpoints").InnerText);
+		currentMoves = int.Parse(attributes.SelectSingleNode("/unit_type/movement").InnerText);
 
 		baseMaxHealth = currentHealth;
 		baseMaxMoves = currentMoves;
@@ -31,7 +32,7 @@ public class Unit : Sprite
 		lifebar.SetValue(baseMaxHealth);
 	}
 
-	public void SetAttributes(System.Collections.Generic.Dictionary<String, String> attributes)
+	public void SetAttributes(XmlDocument attributes)
 	{
 		this.attributes = attributes;
 	}

--- a/units/UnitRegistry.cs
+++ b/units/UnitRegistry.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using Godot;
+using System.Xml;
 
 public class UnitRegistry
 {
-	// FIXME: Godot.Dictionary currently crashes with: "drivers/unix/stream_peer_tcp_posix.cpp:276 - Server disconnected!"
-	static readonly System.Collections.Generic.Dictionary<String, System.Collections.Generic.Dictionary<String, String>> registry = new System.Collections.Generic.Dictionary<String, System.Collections.Generic.Dictionary<String, String>>();
+	// FIXME: check back as c# support gets shaken out to see if Godot's dictionary starts working
+	static readonly System.Collections.Generic.Dictionary<String, XmlDocument> registry = new System.Collections.Generic.Dictionary<String, XmlDocument>();
 
 	private UnitRegistry() { }
 
@@ -18,35 +19,17 @@ public class UnitRegistry
 
 	public static void LoadFile(String file)
 	{
-		using (XMLParser xml = new XMLParser())
+		XmlDocument xml = new XmlDocument();
+		xml.Load(file);
+		String type = xml.DocumentElement.SelectSingleNode("/unit_type/type").InnerText;
+
+		if (!registry.ContainsKey(type))
 		{
-			xml.Open(file);
-
-			System.Collections.Generic.Dictionary<String, String> attributes = new System.Collections.Generic.Dictionary<String, String>();
-			String previous_tag = "";
-			Godot.Error reading = Godot.Error.Ok;
-			while (reading == Godot.Error.Ok)
-			{
-				if (xml.GetNodeType() == XMLParser.NodeType.Element)
-				{
-					previous_tag = xml.GetNodeName();
-				}
-				if (xml.GetNodeType() == XMLParser.NodeType.Text && xml.GetNodeData().Trim().Length() > 0)
-				{
-					attributes[previous_tag] = xml.GetNodeData().Trim();
-				}
-
-				reading = xml.Read();
-			}
-
-			if (!registry.ContainsKey(attributes["type"]))
-			{
-				registry.Add(attributes["type"], attributes);
-			}
-			else
-			{
-				GD.Print("Unit type ", attributes["type"], " already exists!");
-			}
+			registry.Add(type, xml);
+		}
+		else
+		{
+			GD.Print("Unit type ", type, " already exists!");
 		}
 	}
 
@@ -55,9 +38,8 @@ public class UnitRegistry
 		if (registry.ContainsKey(type))
 		{
 			Unit unit = (Unit)((PackedScene)ResourceLoader.Load("res://units/Unit.tscn")).Instance();
-			// TODO: deep copy, or wait for Duplicate() method once Godot.Dictionary is fixed
-			unit.SetAttributes(registry[type]);
-			unit.SetTexture((Texture)ResourceLoader.Load(registry[type]["image"]));
+			unit.SetAttributes((XmlDocument)registry[type].Clone());
+			unit.SetTexture((Texture)ResourceLoader.Load(registry[type].SelectSingleNode("/unit_type/image").InnerText));
 			unit.SetSide(side);
 			unit.SetPosition(map.MapToWorldCentered(new Vector2(x, y)));
 			return unit;


### PR DESCRIPTION
Unit attributes are now retrievable via xpath.

---

As a side note, Godot.Dictionary does not work with <String, XmlDocument> either, so at least for now it seems safe to say that its implementation is generally broken.