### PR TITLE
Adds a validation schema to be used with unit XML.

### DIFF
--- a/game/Game.cs
+++ b/game/Game.cs
@@ -55,10 +55,10 @@ public class Game : Node2D
 			else if (IsUnitAtCell(mouseCell) && activeUnit != null)
 			{
 				Unit unit = (Unit)GetUnitAtCell(mouseCell);
-				
-				if (unit.GetSide() != activeUnit.GetSide() 
-					&& terrain.AreNeighbors(mouseCell, terrain.WorldToMap(activeUnit.GetPosition())) 
-					&& activeUnit.CanAttack() 
+
+				if (unit.GetSide() != activeUnit.GetSide()
+					&& terrain.AreNeighbors(mouseCell, terrain.WorldToMap(activeUnit.GetPosition()))
+					&& activeUnit.CanAttack()
 					&& activeSide == activeUnit.GetSide())
 				{
 					activeUnit.Fight(unit);
@@ -155,12 +155,12 @@ public class Game : Node2D
 
 	public void EndTurn()
 	{
-		foreach(Unit u in units.GetChildren())
+		foreach (Unit u in units.GetChildren())
 		{
 			u.RestoreCurrentMoves();
 			u.RestoreAttack();
 		}
-		
+
 		activeSide = (activeSide % sides) + 1;
 	}
 }

--- a/game/Game.tscn
+++ b/game/Game.tscn
@@ -6,7 +6,7 @@
 [ext_resource path="res://interface/Interface.tscn" type="PackedScene" id=4]
 [ext_resource path="res://interface/WesnothCamera.cs" type="Script" id=5]
 
-[node name="Game" type="Node2D"]
+[node name="Game" type="Node2D" index="0"]
 
 script = ExtResource( 1 )
 _sections_unfolded = [ "Cell", "Transform" ]

--- a/haldric.csproj
+++ b/haldric.csproj
@@ -65,10 +65,27 @@
     <Folder Include="units\config\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="units\config\Fighter.xml" />
-    <None Include="units\config\Vengeance.xml" />
-    <None Include="units\config\Sprite.xml" />
-    <None Include="units\config\Master-Of-Curses.xml" />
+    <None Include="units\config\elves-wood\Archer.xml" />
+    <None Include="units\config\elves-wood\Fighter.xml" />
+    <None Include="units\config\elves-wood\Scout.xml" />
+    <None Include="units\config\elves-wood\Shaman.xml" />
+    <None Include="units\config\orcs\Archer.xml" />
+    <None Include="units\config\orcs\Assassin.xml" />
+    <None Include="units\config\orcs\Grunt.xml" />
+    <None Include="units\config\trolls\Troll-Whelp.xml" />
+    <None Include="units\Units.xsd" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <TextStylePolicy TabWidth="4" TabsToSpaces="False" IndentWidth="4" RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="80" scope="application/xml" />
+          <XmlFormattingPolicy scope="application/xml">
+            <DefaultFormat OmitXmlDeclaration="False" IndentContent="True" AttributesInNewLine="False" MaxAttributesPerLine="10" WrapAttributes="False" AlignAttributes="False" AlignAttributeValues="False" QuoteChar="&quot;" SpacesBeforeAssignment="0" SpacesAfterAssignment="0" EmptyLinesBeforeStart="0" EmptyLinesAfterStart="0" EmptyLinesBeforeEnd="0" EmptyLinesAfterEnd="0" />
+          </XmlFormattingPolicy>
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
 </Project>

--- a/units/UnitRegistry.cs
+++ b/units/UnitRegistry.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using Godot;
 using System.Xml;
+using System.Xml.Schema;
 
 public class UnitRegistry
 {
+	private const String XSD = "units/Units.xsd";
+
 	// FIXME: check back as c# support gets shaken out to see if Godot's dictionary starts working
 	static readonly System.Collections.Generic.Dictionary<String, XmlDocument> registry = new System.Collections.Generic.Dictionary<String, XmlDocument>();
 
@@ -24,11 +27,16 @@ public class UnitRegistry
 
 	public static void LoadFile(String file)
 	{
-		
-		XmlDocument xml = new XmlDocument();
-		xml.Load(file);
-		String type = xml.DocumentElement.SelectSingleNode("/unit_type/type").InnerText;
+		XmlReaderSettings settings = new XmlReaderSettings();
+		settings.ValidationType = ValidationType.Schema;
+		settings.ValidationFlags |= XmlSchemaValidationFlags.ReportValidationWarnings;
+		settings.ValidationEventHandler += ValidationHandler;
+		settings.Schemas.Add(String.Empty, XSD);
 
+		XmlDocument xml = new XmlDocument();
+		xml.Load(XmlReader.Create(file, settings));
+
+		String type = xml.DocumentElement.SelectSingleNode("/unit_type/type").InnerText;
 		if (!registry.ContainsKey(type))
 		{
 			registry.Add(type, xml);
@@ -39,13 +47,25 @@ public class UnitRegistry
 		}
 	}
 
+	static void ValidationHandler(object sender, ValidationEventArgs args)
+	{
+		if (args.Severity == XmlSeverityType.Warning)
+		{
+			GD.Print("The following validation warning occurred: " + args.Message);
+		}
+		else if (args.Severity == XmlSeverityType.Error)
+		{
+			GD.Print("The following critical validation errors occurred: " + args.Message);
+		}
+	}
+
 	public static Unit Create(String type, int side, int x, int y)
 	{
 		if (registry.ContainsKey(type))
 		{
 			Unit unit = (Unit)((PackedScene)ResourceLoader.Load("res://units/Unit.tscn")).Instance();
 			unit.SetAttributes((XmlDocument)registry[type].Clone());
-			unit.SetTexture((Texture)ResourceLoader.Load(registry[type].SelectSingleNode("/unit_type/image").InnerText));
+			unit.SetTexture((Texture)ResourceLoader.Load("res://" + registry[type].SelectSingleNode("/unit_type/image").InnerText));
 			unit.SetSide(side);
 			return unit;
 		}

--- a/units/Units.xsd
+++ b/units/Units.xsd
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="unit_type">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="type">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:pattern value="[a-zA-Z0-9_ ]*"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="name" type="xs:string" />
+                <xs:element name="hitpoints">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:integer">
+                            <xs:minInclusive value="1"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="movement">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:integer">
+                            <xs:minInclusive value="0"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="damage">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:integer">
+                            <xs:minInclusive value="0"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="image" type="xs:string" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/units/config/elves-wood/Archer.xml
+++ b/units/config/elves-wood/Archer.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <unit_type>
-    <type>Elvish Archer</type>
-    <name>Elvish Archer</name>
-    <hitpoints>31</hitpoints>
-    <movement>6</movement>
-    <damage>8</damage>
-    <image>res://units/images/elves-wood/archer.png</image>
+	<type>Elvish Archer</type>
+	<name>Elvish Archer</name>
+	<hitpoints>31</hitpoints>
+	<movement>6</movement>
+	<damage>8</damage>
+	<image>units/images/elves-wood/archer.png</image>
 </unit_type>

--- a/units/config/elves-wood/Fighter.xml
+++ b/units/config/elves-wood/Fighter.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <unit_type>
-    <type>Elvish Fighter</type>
-    <name>Elvish Fighter</name>
-    <hitpoints>34</hitpoints>
-    <movement>5</movement>
-    <damage>9</damage>
-    <image>res://units/images/elves-wood/fighter.png</image>
+	<type>Elvish Fighter</type>
+	<name>Elvish Fighter</name>
+	<hitpoints>34</hitpoints>
+	<movement>5</movement>
+	<damage>9</damage>
+	<image>units/images/elves-wood/fighter.png</image>
 </unit_type>

--- a/units/config/elves-wood/Scout.xml
+++ b/units/config/elves-wood/Scout.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <unit_type>
-    <type>Elvish Scout</type>
-    <name>Elvish Scout</name>
-    <hitpoints>38</hitpoints>
-    <movement>8</movement>
-    <damage>7</damage>
-    <image>res://units/images/elves-wood/scout.png</image>
+	<type>Elvish Scout</type>
+	<name>Elvish Scout</name>
+	<hitpoints>38</hitpoints>
+	<movement>8</movement>
+	<damage>7</damage>
+	<image>units/images/elves-wood/scout.png</image>
 </unit_type>

--- a/units/config/elves-wood/Shaman.xml
+++ b/units/config/elves-wood/Shaman.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <unit_type>
-    <type>Elvish Shaman</type>
-    <name>Elvish Shaman</name>
-    <hitpoints>26</hitpoints>
-    <movement>5</movement>
-    <damage>6</damage>
-    <image>res://units/images/elves-wood/shaman.png</image>
+	<type>Elvish Shaman</type>
+	<name>Elvish Shaman</name>
+	<hitpoints>26</hitpoints>
+	<movement>5</movement>
+	<damage>6</damage>
+	<image>units/images/elves-wood/shaman.png</image>
 </unit_type>

--- a/units/config/ocrs/Archer.xml
+++ b/units/config/ocrs/Archer.xml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<unit_type>
-    <type>Orcish Archer</type>
-    <name>Orcish Archer</name>
-    <hitpoints>30</hitpoints>
-    <movement>5</movement>
-    <damage>10</damage>
-    <image>res://units/images/orcs/archer.png</image>
-</unit_type>

--- a/units/config/ocrs/Assassin.xml
+++ b/units/config/ocrs/Assassin.xml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<unit_type>
-    <type>Orcish Assassin</type>
-    <name>Orcish Assassin</name>
-    <hitpoints>25</hitpoints>
-    <movement>6</movement>
-    <damage>8</damage>
-    <image>res://units/images/orcs/assassin.png</image>
-</unit_type>

--- a/units/config/ocrs/Grunt.xml
+++ b/units/config/ocrs/Grunt.xml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<unit_type>
-    <type>Orcish Grunt</type>
-    <name>Orcish Grunt</name>
-    <hitpoints>40</hitpoints>
-    <movement>5</movement>
-    <damage>10</damage>
-    <image>res://units/images/orcs/grunt.png</image>
-</unit_type>

--- a/units/config/orcs/Archer.xml
+++ b/units/config/orcs/Archer.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<unit_type>
+	<type>Orcish Archer</type>
+	<name>Orcish Archer</name>
+	<hitpoints>30</hitpoints>
+	<movement>5</movement>
+	<damage>10</damage>
+	<image>units/images/orcs/archer.png</image>
+</unit_type>

--- a/units/config/orcs/Assassin.xml
+++ b/units/config/orcs/Assassin.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<unit_type>
+	<type>Orcish Assassin</type>
+	<name>Orcish Assassin</name>
+	<hitpoints>25</hitpoints>
+	<movement>6</movement>
+	<damage>8</damage>
+	<image>units/images/orcs/assassin.png</image>
+</unit_type>

--- a/units/config/orcs/Grunt.xml
+++ b/units/config/orcs/Grunt.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<unit_type>
+	<type>Orcish Grunt</type>
+	<name>Orcish Grunt</name>
+	<hitpoints>40</hitpoints>
+	<movement>5</movement>
+	<damage>10</damage>
+	<image>units/images/orcs/grunt.png</image>
+</unit_type>

--- a/units/config/trolls/Troll-Whelp.xml
+++ b/units/config/trolls/Troll-Whelp.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <unit_type>
-    <type>Troll Whelp</type>
-    <name>Troll Whelp</name>
-    <hitpoints>42</hitpoints>
-    <movement>4</movement>
-    <damage>9</damage>
-    <image>res://units/images/trolls/whelp.png</image>
+	<type>Troll Whelp</type>
+	<name>Troll Whelp</name>
+	<hitpoints>42</hitpoints>
+	<movement>4</movement>
+	<damage>9</damage>
+	<image>units/images/trolls/whelp.png</image>
 </unit_type>


### PR DESCRIPTION
Currently checks that:
The unit's type contains only alphanumeric characters, spaces, or underscores
The unit's name is a valid string
The unit's hitpoints are a valid integer and >= 1
The unit's movement a a valid integer and >= 0
The unit's damage is a valid integer and >= 0
The unit's image path is a valid string