### PR TITLE
Added basic Wesnoth-like macro functionality for YAML configs.

### DIFF
--- a/game/Game.gd
+++ b/game/Game.gd
@@ -20,6 +20,7 @@ onready var map = $"Map"
 onready var units = $"UnitContainer"
 
 func _ready():
+	MacroRegistry.load_dir("res://macros")
 	UnitRegistry.load_dir("res://units/config")
 	UnitRegistry.validate_advancements()
 	

--- a/global/MacroRegistry.gd
+++ b/global/MacroRegistry.gd
@@ -1,0 +1,107 @@
+extends Node
+
+var macros = {}
+
+# #
+# Loops recursively over all files in the provided path.
+# The header is the first line of the macro, which contains the list of argument names.
+# Everything else is the text of the macro to be substituted in.
+# #
+func load_dir(path):
+	var dir = Directory.new()
+	dir.open(path)
+	dir.list_dir_begin(true, true)
+	var sub_path
+	while true:
+		sub_path = dir.get_next()
+		if sub_path == "." or sub_path == "..":
+			continue
+		if sub_path == "":
+			break
+		if dir.current_is_dir():
+			load_dir(dir.get_current_dir() + "/" + sub_path)
+		else:
+			var file = File.new()
+			if file.open(dir.get_current_dir() + "/" + sub_path, file.READ) == OK:
+				var contents = file.get_as_text().split("\n")
+				
+				macros[sub_path.split(".")[0]] = {}
+				macros[sub_path.split(".")[0]].header = contents[0]
+				contents.remove(0)
+				macros[sub_path.split(".")[0]].text = contents
+	dir.list_dir_end()
+
+# #
+# Checks each line to see if it contains the "{" character.
+# If yes, then either substitute in a multi-line macro text or a single inline value
+# #
+func substitute(contents):
+	var lines = contents.split("\n")
+	var length = lines.size()
+	var i = 0
+	
+	while i < length:
+		if(lines[i].find("{") != -1):
+# if there are no non-whitespace leading characters, get the indentation and prepend that to all lines substituted in over the macro
+			if(lines[i].dedent().find("{") == 0):
+				var indent = lines[i].substr(0, lines[i].find("{"))
+				var macro = get_name(lines[i])
+				var ids = get_ids(macros[macro].header)
+				set_id_values(lines[i].dedent(), ids)
+				
+				lines.remove(i)
+				for j in macros[macro].text.size():
+					lines.insert(i+j, indent+macros[macro].text[j])
+					for key in ids.keys():
+						if lines[i+j].find("{"+key+"}") != -1:
+							lines[i+j] = lines[i+j].replace("{"+key+"}", ids[key])
+				
+				length = lines.size()
+				i = i -1
+# otherwise, this is an inline replacement so just drop in the value
+			else:
+				var macro = get_name(lines[i])
+				lines[i] = lines[i].replace("{"+macro+"}", macros[macro].text[0])
+		i = i + 1
+	
+	contents = ""
+	for line in lines:
+		if line.dedent().length() != 0:
+			contents = contents + line + "\n"
+	return contents
+
+# #
+# Retrieves the name of the macro from the line of text.
+# #
+func get_name(line):
+	line = line.dedent()
+	var name_start = line.find("{")+1
+	var name_length = line.find(" ", name_start)-1
+	if name_length == -2:
+		name_length = line.find("}")-name_start
+	return line.substr(name_start, name_length)
+
+# #
+# Retrieves the substitution arguments from the first line of the macro.
+# #
+func get_ids(header):
+	var ids = {}
+	var ids_list = header.split(" ")
+	
+	ids_list.remove(0)
+	for id in ids_list:
+		ids[id] = ""
+	
+	return ids
+
+# #
+# Sets what values to use in place of the macro arguments.
+# TODO: support values containing spaces
+# #
+func set_id_values(line, ids):
+	var values = line.split("}")[0].split(" ")
+	var keys = ids.keys()
+	
+	values.remove(0)
+	for i in keys.size():
+		ids[keys[i]] = values[i]

--- a/global/UnitRegistry.gd
+++ b/global/UnitRegistry.gd
@@ -8,7 +8,7 @@ func load_dir(path):
 	var files = []
 	files = get_files_in_directory(path, files)
 	for file in files:
-		var unit = yaml_parser.parse(file.get_as_text())
+		var unit = yaml_parser.parse(MacroRegistry.substitute(file.get_as_text()))
 		registry[unit.id] = {
 			id = unit.id,
 			name = unit.name,

--- a/macros/BASIC_ATTACK.yaml
+++ b/macros/BASIC_ATTACK.yaml
@@ -1,0 +1,7 @@
+# NAME TYPE RANGE DAMAGE STRIKES
+attack:
+  name: {NAME}
+  type: {TYPE}
+  range: {RANGE}
+  damage: {DAMAGE}
+  strikes: {STRIKES}

--- a/macros/NOTHING.yaml
+++ b/macros/NOTHING.yaml
@@ -1,0 +1,2 @@
+# NOTHING
+null

--- a/macros/RESIST.yaml
+++ b/macros/RESIST.yaml
@@ -1,0 +1,8 @@
+# ARCANE BLADE COLD FIRE IMPACT PIERCE
+resistance:
+  arcane: {ARCANE}
+  blade: {BLADE}
+  cold: {COLD}
+  fire: {FIRE}
+  impact: {IMPACT}
+  pierce: {PIERCE}

--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.png"
 
 UnitRegistry="*res://global/UnitRegistry.gd"
 MapLoader="*res://global/MapLoader.gd"
+MacroRegistry="*res://global/MacroRegistry.gd"
 
 [display]
 

--- a/units/config/elves-wood/Shaman.yaml
+++ b/units/config/elves-wood/Shaman.yaml
@@ -4,23 +4,12 @@ level: 1
 health: 26
 moves: 5
 experience: 32
-advances_to: null
+advances_to: {NOTHING}
 image: res://units/images/elves-wood/shaman.png
 
-attack:
-  name: staff
-  type: impact
-  range: melee
-  damage: 3
-  strikes: 2
+{BASIC_ATTACK staff impact melee 3 2}
 
-resistance:
-  blade: 100
-  pierce: 100
-  impact: 100
-  fire: 100
-  cold: 100
-  arcane: 110
+{RESIST 110 100 100 100 100 100}
 
 defense:
   flat: 40


### PR DESCRIPTION
See Shaman.yaml for a proof of concept for multi-line and single value replacements.

This currently doesn't support substituting values that have spaces in them, nor does it do any sort of validation (for example that the arguments defined match the arguments provided), and could do with a bit of a code cleanup, but it is functional.

---

This may not be suitable for merging as-is, but either way I'd like to know if I should continue with this, since it sounds like there's still some uncertainty about whether this is wanted functionality.