### PR TITLE
Map editor improvements

### DIFF
--- a/source/editor/Editor.gd
+++ b/source/editor/Editor.gd
@@ -67,6 +67,7 @@ func _new_map() -> void:
 	scenario_container.add_child(scenario)
 	scenario.map.set_size(DEFAULT_MAP_SIZE)
 	scenario.update_size()
+	scenario.map.initialize()
 
 func _load_map(scenario_name: String) -> void:
 	var packed_scene = load(DEFAULT_ROOT_PATH + scenario_name + ".tscn")

--- a/source/scenario/map/Map.gd
+++ b/source/scenario/map/Map.gd
@@ -203,7 +203,6 @@ func update_terrain_from_map_data(map_data: Dictionary) -> void:
 	pass
 
 func update_terrain() -> void:
-	# TODO: no need to update everything. Restrict this to specific rects
 	_update_locations()
 	transitions.update_transitions()
 
@@ -287,6 +286,7 @@ func set_tile(global_pos: Vector2, id: int) -> void:
 		set_cellv(cell, id)
 
 	_update_size()
+	transitions.add_changed_tile(cell)
 
 func get_village_count() -> int:
 	return overlay.get_used_cells_by_id(overlay.tile_set.find_tile_by_name("^Vh")).size()


### PR DESCRIPTION

Hello,

here are two commits fixing two issues:
1. Open Map Editor and try to map any tile -> it crashes because Map.initialize() was never called so I've added call to it in Editor.gd
2. Mapping was painfully slow (especially when mapping many tiles with multiple single clicks) because every time tile was changed all cell transitions were updated - now only changed cell and it's neighbors are updated

preview - it still works and is faster (gif is speeded up but you can see that there is no lag):


![mapping](https://user-images.githubusercontent.com/9964886/67978244-fa959600-fc19-11e9-9a26-3afb8716b668.gif)

I'd love to contribute more to haldric so if my help is needed just tell me.
