### PR TITLE
Implement first version of minimap

### DIFF
--- a/source/interface/hud/HUD.tscn
+++ b/source/interface/hud/HUD.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://source/interface/hud/HUD.gd" type="Script" id=1]
 [ext_resource path="res://source/interface/hud/AdvancementPopup.tscn" type="PackedScene" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://source/interface/hud/TurnEndPanel.tscn" type="PackedScene" id=6]
 [ext_resource path="res://source/interface/pause_menu/PauseMenu.tscn" type="PackedScene" id=7]
 [ext_resource path="res://source/interface/hud/AttackPopup.tscn" type="PackedScene" id=8]
+[ext_resource path="res://source/interface/hud/Minimap.tscn" type="PackedScene" id=9]
 
 [node name="HUD" type="CanvasLayer"]
 script = ExtResource( 1 )
@@ -24,17 +25,28 @@ margin_right = 200.0
 margin_bottom = 300.0
 
 [node name="SidePanel" parent="." instance=ExtResource( 3 )]
-margin_top = 10.0
-margin_bottom = 60.0
+margin_left = -1.75806
+margin_top = 11.7581
+margin_right = -1.75806
+margin_bottom = 61.7581
+
+[node name="Minimap" parent="." instance=ExtResource( 9 )]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -249.0
+margin_top = 106.0
+margin_right = -10.0
+margin_bottom = 286.0
+rect_min_size = Vector2( 180, 180 )
 
 [node name="UnitPanel" parent="." instance=ExtResource( 4 )]
 anchor_left = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = -250.0
-margin_top = 100.0
-margin_right = -10.0
-margin_bottom = -100.0
+margin_left = -249.098
+margin_top = 301.903
+margin_right = -9.09766
+margin_bottom = -99.0975
 mouse_filter = 2
 
 [node name="ToDPanel" parent="." instance=ExtResource( 5 )]
@@ -50,12 +62,17 @@ anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = -250.0
+margin_left = -247.544
 margin_top = -90.0
-margin_right = -10.0
+margin_right = -7.54443
 margin_bottom = -10.0
 
 [node name="PauseMenu" parent="." instance=ExtResource( 7 )]
+visible = false
+margin_left = 2.86401
+margin_top = 1.43198
+margin_right = 2.86401
+margin_bottom = 1.43201
 
 [node name="AttackPopup" parent="." instance=ExtResource( 8 )]
 visible = true

--- a/source/interface/hud/Minimap.gd
+++ b/source/interface/hud/Minimap.gd
@@ -1,0 +1,40 @@
+extends Control
+
+onready var minimap_camera := $MinimapViewportContainer/Viewport/Camera2D as Camera2D
+onready var minimap_viewport_container := $MinimapViewportContainer
+onready var viewport := $MinimapViewportContainer/Viewport as Viewport 
+onready var area_of_view := $MinimapAreaOfView as Control
+
+var map_pixel_size : Vector2
+
+signal map_position_change_requested
+
+func initialize(world_2d : World2D, map_pixel_size : Vector2, main_camera : Camera2D) -> void:
+	viewport.world_2d = world_2d
+	# todo: - will need update for resizing probably
+	minimap_camera.zoom = map_pixel_size / rect_size
+	minimap_camera.position = map_pixel_size / 2
+	
+	self.map_pixel_size = map_pixel_size
+	# todo: - will need update for resizing probably
+	
+	main_camera.connect("position_changed", self, "_on_map_camera_position_changed")
+	main_camera.connect("zoom_changed", self, "_on_map_camera_zoom_changed")
+	
+	area_of_view.rect_size = main_camera.zoom * rect_size
+	area_of_view.rect_pivot_offset = rect_size / 2
+	_on_map_camera_position_changed(main_camera.position)
+	
+	minimap_viewport_container.connect("minimap_area_of_view_moved", self, "_on_minimap_area_of_view_moved")
+
+
+func _on_minimap_area_of_view_moved(move_target: Vector2):
+	emit_signal("map_position_change_requested", move_target * minimap_camera.zoom)
+
+#this is center of camera view
+func _on_map_camera_position_changed(new_position : Vector2) -> void:
+	area_of_view.rect_position = (new_position / minimap_camera.zoom) - (area_of_view.rect_size / 2)
+
+
+func _on_map_camera_zoom_changed(new_zoom : Vector2) -> void:
+	area_of_view.rect_scale = new_zoom 

--- a/source/interface/hud/Minimap.tscn
+++ b/source/interface/hud/Minimap.tscn
@@ -1,0 +1,53 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://graphics/images/interface/panels.png" type="Texture" id=1]
+[ext_resource path="res://source/interface/hud/Minimap.gd" type="Script" id=2]
+[ext_resource path="res://source/interface/hud/MinimapAreaOfView.gd" type="Script" id=3]
+[ext_resource path="res://source/interface/hud/MinimapViewportContainer.gd" type="Script" id=4]
+
+[node name="Minimap" type="Control"]
+margin_right = 240.0
+margin_bottom = 180.0
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MinimapViewportContainer" type="ViewportContainer" parent="."]
+margin_right = 240.0
+margin_bottom = 180.0
+stretch = true
+script = ExtResource( 4 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Viewport" type="Viewport" parent="MinimapViewportContainer"]
+size = Vector2( 240, 180 )
+transparent_bg = true
+handle_input_locally = false
+render_target_update_mode = 3
+
+[node name="Camera2D" type="Camera2D" parent="MinimapViewportContainer/Viewport"]
+current = true
+zoom = Vector2( 10, 10 )
+
+[node name="NinePatchRect" type="NinePatchRect" parent="."]
+margin_right = 240.0
+margin_bottom = 180.0
+texture = ExtResource( 1 )
+region_rect = Rect2( 60, 0, 20, 20 )
+patch_margin_left = 4
+patch_margin_top = 4
+patch_margin_right = 4
+patch_margin_bottom = 4
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MinimapAreaOfView" type="Control" parent="."]
+mouse_filter = 2
+script = ExtResource( 3 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/source/interface/hud/MinimapAreaOfView.gd
+++ b/source/interface/hud/MinimapAreaOfView.gd
@@ -1,0 +1,7 @@
+extends Control
+
+func _draw ():
+	draw_line(rect_position, rect_position + Vector2(rect_size.x , 0), Color(1, 1, 1))
+	draw_line(rect_position, rect_position + Vector2(0 , rect_size.y), Color(1, 1, 1))
+	draw_line(rect_position + Vector2(0 , rect_size.y), rect_position + rect_size, Color(1, 1, 1))
+	draw_line(rect_position + Vector2(rect_size.x , 0), rect_position + rect_size, Color(1, 1, 1))

--- a/source/interface/hud/MinimapViewportContainer.gd
+++ b/source/interface/hud/MinimapViewportContainer.gd
@@ -1,0 +1,19 @@
+extends ViewportContainer
+
+signal minimap_area_of_view_moved
+
+var dragging = false
+
+func _gui_input(event : InputEvent) -> void:
+	
+	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and event.is_pressed():
+		dragging = true
+		
+	if event is InputEventMouseMotion and dragging:
+		emit_signal("minimap_area_of_view_moved", event.position)
+	
+	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and not event.is_pressed():
+		dragging = false
+		emit_signal("minimap_area_of_view_moved", event.position)
+	
+	


### PR DESCRIPTION
Hi this commit implements minimap in game view. Here is preview (well now minimap is aligned correctly but I did not bother to record another gif) https://gfycat.com/tenderwethog but I really ecourage you to build yourself and check it out.

**Features:**
- adds minimap that is another viewport of game world
- shows which area is currently visible with white rect on minimap
- clicking to particular point on minimap moves camera there
- dragging 'area of view' on minimap moves main camera too
- Minimap node is constructed in such a way that all it needs is to have viewport of main world passed and one signal from WesnothCamera connected (to know if user moves camera) so it is highly reusable

**Known issues**
- when main camera leaves the map area of view on minimap also leaves minimap which looks weird
![image](https://user-images.githubusercontent.com/9964886/68526225-d735af80-02d9-11ea-9319-470e73d03e3a.png) I have decided to not fix this issue with some minimap logic because we probably should not allow user to see what is outside the map and if we do this then minimap issue won't be present.
- sometimes area of view on minimap moves slighly off we really see (try draggin it a bunch to see what I'm talking about). Then after some moving it comes back to original position. I spent fair amount of time thinking of what is going on without much merit, so I'd rather have this merged and file separate bug to solve the issue, there is probably something wrong with the way I calculate view  position (see `_on_map_camera_position_changed` in `Minimap.gd`)
- minimap not present in map editor - this requires some more work on Editor scene and I did not want to swell already big PR - will add it later
- minimap does not update correctly when screen is resized - I'll add it later
