### PR TITLE
Show unit in a unit panel only if it is visible to the player

### DIFF
--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -41,7 +41,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	elif event is InputEventMouseMotion and loc:
 		# Show the hovered unit in the sidebar.
 		# If no unit is at the hovered location, display the currently selected unit, if any.
-		if loc.unit:
+		if loc.unit and loc.unit.visible:
 			HUD.update_unit_info(loc.unit)
 		elif current_unit:
 			HUD.update_unit_info(current_unit)


### PR DESCRIPTION
Fixes bug when hovering mouse over unit in fog of war would cause unit panel to show field with this unit.