### PR TITLE
Minimap in editor

### DIFF
--- a/source/editor/Editor.gd
+++ b/source/editor/Editor.gd
@@ -7,21 +7,20 @@ const DEFAULT_MAP_SIZE := Vector2(44, 33)
 export var button_size := 60
 
 onready var HUD := $HUD as CanvasLayer
-onready var scenario_container := $ScenarioContainer as Node
+onready var scenario_container := $ScenarioLayer/ViewportContainer/Viewport/ScenarioContainer as Node
 onready var line_edit := $HUD/UIButtons/HBoxContainer/LineEdit as LineEdit
+onready var camera := $ScenarioLayer/ViewportContainer/Viewport/Camera2D
 
 var scenario: Scenario = null
 var current_paint_tile := 0
 var current_clear_tile := 0
 
 func _unhandled_input(event: InputEvent) -> void:
-	var mouse_position: Vector2 = get_global_mouse_position()
-
 	if Input.is_action_pressed("mouse_left"):
-		scenario.map.set_tile(mouse_position, current_paint_tile)
+		scenario.map.set_tile(current_paint_tile)
 
 	if Input.is_action_pressed("mouse_right"):
-		scenario.map.set_tile(mouse_position, current_clear_tile)
+		scenario.map.set_tile(current_clear_tile)
 
 	if Input.is_action_just_released("mouse_left") or Input.is_action_just_released("mouse_right"):
 		_update()
@@ -35,6 +34,9 @@ func _ready() -> void:
 func _update() -> void:
 	scenario.map.update_terrain()
 
+func get_camera_zoom() -> Vector2:
+	return camera.zoom
+	
 func _setup_scenario() -> void:
 	for id in scenario.map.tile_set.get_tiles_ids():
 		_add_terrain_button(id)
@@ -68,6 +70,7 @@ func _new_map() -> void:
 	scenario.map.set_size(DEFAULT_MAP_SIZE)
 	scenario.update_size()
 	scenario.map.initialize()
+	
 
 func _load_map(scenario_name: String) -> void:
 	var packed_scene = load(DEFAULT_ROOT_PATH + scenario_name + ".tscn")
@@ -83,6 +86,7 @@ func _load_map(scenario_name: String) -> void:
 
 	scenario = packed_scene.instance()
 	scenario_container.add_child(scenario)
+	
 
 func _save_map(scenario_name: String) -> void:
 	if scenario_name.empty():

--- a/source/editor/Editor.gd
+++ b/source/editor/Editor.gd
@@ -10,6 +10,8 @@ onready var HUD := $HUD as CanvasLayer
 onready var scenario_container := $ScenarioLayer/ViewportContainer/Viewport/ScenarioContainer as Node
 onready var line_edit := $HUD/UIButtons/HBoxContainer/LineEdit as LineEdit
 onready var camera := $ScenarioLayer/ViewportContainer/Viewport/Camera2D
+onready var scenario_viewport := $ScenarioLayer/ViewportContainer/Viewport as Viewport
+onready var minimap := $HUD/Minimap as Control
 
 var scenario: Scenario = null
 var current_paint_tile := 0
@@ -28,6 +30,9 @@ func _unhandled_input(event: InputEvent) -> void:
 func _ready() -> void:
 	_new_map()
 	_setup_scenario()
+	
+	minimap.initialize(scenario_viewport, scenario.map.get_pixel_size(), camera)
+	minimap.connect("map_position_change_requested", self, "_on_map_position_change_requested")
 
 	current_clear_tile = scenario.map.default_tile
 
@@ -130,3 +135,7 @@ func _on_Load_pressed() -> void:
 
 func _on_New_pressed() -> void:
 	_new_map()
+
+func _on_map_position_change_requested(new_position: Vector2) -> void:
+	camera.focus_on(new_position)
+

--- a/source/editor/Editor.tscn
+++ b/source/editor/Editor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://source/editor/Editor.gd" type="Script" id=1]
 [ext_resource path="res://source/scenario/OffMap.tscn" type="PackedScene" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://graphics/materials/panel_blur.tres" type="Material" id=6]
 [ext_resource path="res://source/interface/pause_menu/PauseMenu.tscn" type="PackedScene" id=7]
 [ext_resource path="res://source/interface/camera/WesnothCamera.tscn" type="PackedScene" id=8]
+[ext_resource path="res://source/interface/hud/Minimap.tscn" type="PackedScene" id=9]
 
 [node name="Editor" type="Node2D"]
 script = ExtResource( 1 )
@@ -21,8 +22,8 @@ layer = 0
 [node name="ViewportContainer" type="ViewportContainer" parent="ScenarioLayer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_right = 0.00012207
 mouse_filter = 2
+stretch = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -31,20 +32,34 @@ __meta__ = {
 size = Vector2( 1920, 1080 )
 transparent_bg = true
 handle_input_locally = false
+hdr = false
+disable_3d = true
+usage = 0
 render_target_update_mode = 3
 
 [node name="ScenarioContainer" type="Node" parent="ScenarioLayer/ViewportContainer/Viewport"]
 
 [node name="Camera2D" parent="ScenarioLayer/ViewportContainer/Viewport" instance=ExtResource( 8 )]
+position = Vector2( 960, 540 )
 
 [node name="HUD" type="CanvasLayer" parent="."]
 script = ExtResource( 3 )
+
+[node name="Minimap" parent="HUD" instance=ExtResource( 9 )]
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -256.0
+margin_top = 25.0
+margin_right = -17.0
+margin_bottom = -875.0
 
 [node name="TileButtons" type="Control" parent="HUD"]
 anchor_left = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = -265.0
+margin_top = 250.0
 margin_bottom = 1.0
 theme = ExtResource( 4 )
 __meta__ = {
@@ -66,6 +81,9 @@ size_flags_vertical = 3
 custom_constants/vseparation = 12
 custom_constants/hseparation = 12
 columns = 4
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="UIButtons" type="Control" parent="HUD"]
 anchor_left = 0.5
@@ -90,6 +108,9 @@ margin_right = -1.0
 margin_bottom = -5.0
 custom_constants/separation = 20
 alignment = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="New" type="Button" parent="HUD/UIButtons/HBoxContainer"]
 margin_left = 69.0
@@ -122,6 +143,7 @@ rect_min_size = Vector2( 80, 0 )
 text = "Load"
 
 [node name="PauseMenu" parent="HUD" instance=ExtResource( 7 )]
+visible = false
 [connection signal="pressed" from="HUD/UIButtons/HBoxContainer/New" to="." method="_on_New_pressed"]
 [connection signal="pressed" from="HUD/UIButtons/HBoxContainer/Save" to="." method="_on_Save_pressed"]
 [connection signal="pressed" from="HUD/UIButtons/HBoxContainer/Load" to="." method="_on_Load_pressed"]

--- a/source/editor/Editor.tscn
+++ b/source/editor/Editor.tscn
@@ -15,19 +15,41 @@ button_size = 50
 
 [node name="OffMap" parent="." instance=ExtResource( 2 )]
 
-[node name="ScenarioContainer" type="Node" parent="."]
+[node name="ScenarioLayer" type="CanvasLayer" parent="."]
+layer = 0
+
+[node name="ViewportContainer" type="ViewportContainer" parent="ScenarioLayer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = 0.00012207
+mouse_filter = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Viewport" type="Viewport" parent="ScenarioLayer/ViewportContainer"]
+size = Vector2( 1920, 1080 )
+transparent_bg = true
+handle_input_locally = false
+render_target_update_mode = 3
+
+[node name="ScenarioContainer" type="Node" parent="ScenarioLayer/ViewportContainer/Viewport"]
+
+[node name="Camera2D" parent="ScenarioLayer/ViewportContainer/Viewport" instance=ExtResource( 8 )]
 
 [node name="HUD" type="CanvasLayer" parent="."]
 script = ExtResource( 3 )
 
 [node name="TileButtons" type="Control" parent="HUD"]
-editor/display_folded = true
 anchor_left = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = -265.0
 margin_bottom = 1.0
 theme = ExtResource( 4 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Panel" parent="HUD/TileButtons" instance=ExtResource( 5 )]
 material = ExtResource( 6 )
@@ -46,7 +68,6 @@ custom_constants/hseparation = 12
 columns = 4
 
 [node name="UIButtons" type="Control" parent="HUD"]
-editor/display_folded = true
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
@@ -57,6 +78,9 @@ margin_right = 300.0
 margin_bottom = -10.0
 rect_min_size = Vector2( 600, 80 )
 theme = ExtResource( 4 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HUD/UIButtons"]
 anchor_right = 1.0
@@ -80,7 +104,6 @@ margin_right = 329.0
 margin_bottom = 69.0
 rect_min_size = Vector2( 160, 0 )
 focus_mode = 1
-focus_mode = 1
 context_menu_enabled = false
 placeholder_text = "scenario name"
 
@@ -99,8 +122,6 @@ rect_min_size = Vector2( 80, 0 )
 text = "Load"
 
 [node name="PauseMenu" parent="HUD" instance=ExtResource( 7 )]
-
-[node name="Camera2D" parent="." instance=ExtResource( 8 )]
 [connection signal="pressed" from="HUD/UIButtons/HBoxContainer/New" to="." method="_on_New_pressed"]
 [connection signal="pressed" from="HUD/UIButtons/HBoxContainer/Save" to="." method="_on_Save_pressed"]
 [connection signal="pressed" from="HUD/UIButtons/HBoxContainer/Load" to="." method="_on_Load_pressed"]

--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -69,7 +69,7 @@ func _ready() -> void:
 	
 	_load_scenario()
 	
-	$HUD/Minimap.initialize(scenario_viewport.world_2d, scenario.map.get_pixel_size(), camera)
+	$HUD/Minimap.initialize(scenario_viewport, scenario.map.get_pixel_size(), camera)
 	$HUD/Minimap.connect("map_position_change_requested", self, "_on_map_position_change_requested")
 
 	# warning-ignore:return_value_discarded

--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -105,6 +105,10 @@ func _load_scenario() -> void:
 
 	draw.map_area = scenario.map.get_pixel_size()
 
+# used in map for workaround on nested viewports issue
+func get_camera_zoom() -> Vector2:
+	return camera.zoom
+
 func _draw_temp_path(path: Array) -> void:
 	if current_unit:
 		var new_path = path.duplicate(true)

--- a/source/interface/hud/Minimap.gd
+++ b/source/interface/hud/Minimap.gd
@@ -5,36 +5,34 @@ onready var minimap_viewport_container := $MinimapViewportContainer
 onready var viewport := $MinimapViewportContainer/Viewport as Viewport 
 onready var area_of_view := $MinimapAreaOfView as Control
 
-var map_pixel_size : Vector2
-
 signal map_position_change_requested
 
-func initialize(world_2d : World2D, map_pixel_size : Vector2, main_camera : Camera2D) -> void:
-	viewport.world_2d = world_2d
+func initialize(main_viewport : Viewport, map_pixel_size : Vector2, main_camera : Camera2D) -> void:
+	viewport.world_2d = main_viewport.world_2d
+	
 	# todo: - will need update for resizing probably
 	minimap_camera.zoom = map_pixel_size / rect_size
 	minimap_camera.position = map_pixel_size / 2
 	
-	self.map_pixel_size = map_pixel_size
-	# todo: - will need update for resizing probably
-	
 	main_camera.connect("position_changed", self, "_on_map_camera_position_changed")
 	main_camera.connect("zoom_changed", self, "_on_map_camera_zoom_changed")
 	
-	area_of_view.rect_size = main_camera.zoom * rect_size
-	area_of_view.rect_pivot_offset = rect_size / 2
+	area_of_view.rect_size = main_camera.zoom * main_viewport.size / minimap_camera.zoom
 	_on_map_camera_position_changed(main_camera.position)
-	
 	minimap_viewport_container.connect("minimap_area_of_view_moved", self, "_on_minimap_area_of_view_moved")
-
 
 func _on_minimap_area_of_view_moved(move_target: Vector2):
 	emit_signal("map_position_change_requested", move_target * minimap_camera.zoom)
 
-#this is center of camera view
+# new position here is center of camera view
 func _on_map_camera_position_changed(new_position : Vector2) -> void:
-	area_of_view.rect_position = (new_position / minimap_camera.zoom) - (area_of_view.rect_size / 2)
-
+	var new_minimap_position = (new_position / minimap_camera.zoom) 
+	var area_of_view_offset = (area_of_view.rect_size / 2) * area_of_view.rect_scale
+	area_of_view.rect_position = new_minimap_position - area_of_view_offset
 
 func _on_map_camera_zoom_changed(new_zoom : Vector2) -> void:
-	area_of_view.rect_scale = new_zoom 
+	var old_rect_size = area_of_view.rect_size * area_of_view.rect_scale
+	var new_rect_size = area_of_view.rect_size * new_zoom
+	var size_diff = old_rect_size - new_rect_size
+	area_of_view.rect_position += size_diff / 2
+	area_of_view.rect_scale = new_zoom

--- a/source/interface/hud/Minimap.tscn
+++ b/source/interface/hud/Minimap.tscn
@@ -26,6 +26,8 @@ __meta__ = {
 size = Vector2( 240, 180 )
 transparent_bg = true
 handle_input_locally = false
+disable_3d = true
+usage = 0
 render_target_update_mode = 3
 
 [node name="Camera2D" type="Camera2D" parent="MinimapViewportContainer/Viewport"]

--- a/source/interface/hud/MinimapAreaOfView.gd
+++ b/source/interface/hud/MinimapAreaOfView.gd
@@ -1,7 +1,12 @@
 extends Control
 
 func _draw ():
-	draw_line(rect_position, rect_position + Vector2(rect_size.x , 0), Color(1, 1, 1))
-	draw_line(rect_position, rect_position + Vector2(0 , rect_size.y), Color(1, 1, 1))
-	draw_line(rect_position + Vector2(0 , rect_size.y), rect_position + rect_size, Color(1, 1, 1))
-	draw_line(rect_position + Vector2(rect_size.x , 0), rect_position + rect_size, Color(1, 1, 1))
+	var t = get_parent().viewport.canvas_transform
+	# for whatever reason origin transform of viewport is incorrect at the start
+	t[2] = Vector2(0,0)
+	var translated_pos = t.xform(rect_position)
+	draw_line(translated_pos, translated_pos + Vector2(rect_size.x , 0), Color(1, 1, 1))
+	draw_line(translated_pos, translated_pos + Vector2(0 , rect_size.y), Color(1, 1, 1))
+	draw_line(translated_pos + Vector2(0 , rect_size.y), translated_pos + rect_size, Color(1, 1, 1))
+	draw_line(translated_pos + Vector2(rect_size.x , 0), translated_pos + rect_size, Color(1, 1, 1))
+

--- a/source/scenario/map/Map.gd
+++ b/source/scenario/map/Map.gd
@@ -48,8 +48,8 @@ func get_viewport_mouse_position() -> Vector2:
 	Workaround for bug https://github.com/godotengine/godot/issues/32222
 	"""
 	var offset_position := Vector2()
-	if get_tree().current_scene.name == 'Game':
-		var zoom = get_parent().get_parent().get_node("Camera2D").zoom # We need to adjust the mouse cursor further by the camera's zoom level
+	if get_tree().current_scene.name == 'Game' || get_tree().current_scene.name == 'Editor':
+		var zoom = get_tree().current_scene.get_camera_zoom() # We need to adjust the mouse cursor further by the camera's zoom level
 		offset_position = get_tree().current_scene.get_global_mouse_position() - get_viewport_transform().origin
 		offset_position *= zoom
 	else:
@@ -265,8 +265,13 @@ func set_size(size: Vector2) -> void:
 	_initialize_locations()
 	_initialize_grid()
 
-func set_tile(global_pos: Vector2, id: int) -> void:
-	var cell: Vector2 = world_to_map(global_pos)
+
+func set_tile(id: int) -> void:
+	"""
+	Sets tile in current mouse position
+	"""
+	
+	var cell: Vector2 = world_to_map(get_viewport_mouse_position())
 
 	if not _is_cell_in_map(cell):
 		return


### PR DESCRIPTION
Hello, please review this PR that adds minimap to map editor. I am submitting two commits - one for changing structure of map editor to work with viewport and other for adding and fixing minimap

**Features:**

- minimap is now present and working in map editor:
![image](https://user-images.githubusercontent.com/9964886/68680869-ac11c100-0562-11ea-8a9d-50468a540853.png)

- editor scene was refactored to work with viewport and is now more similar go game scene in that regard. Having viewport was required to have minimap working. New structure looks like this:
![image](https://user-images.githubusercontent.com/9964886/68681016-e8ddb800-0562-11ea-8d9c-a481e9083257.png)

- minimap was issues with area of view positioning was resolved, also now real viewport size is used to determine size of area of view rectangle

**Know issues:**

- changing screen resolution or resizing game window will still break minimap