### PR TITLE
Fix lack of tiles transitions in game

### DIFF
--- a/source/scenario/map/Transitions.gd
+++ b/source/scenario/map/Transitions.gd
@@ -24,8 +24,13 @@ func initialize(map: TileMap) -> void:
 		add_child(transition_map)
 
 	layers = get_children()
-
-	update_transitions()
+	_update_all_transitions()
+	
+func _update_all_transitions():
+	for layer in layers:
+		layer.clear()
+	for cell in map.get_used_cells():
+		_apply_transition_from_cell(cell, true)
 
 func update_transitions() -> void:
 	for cell in changed_tiles:


### PR DESCRIPTION
Hi,
this patch fixes regression that I have introduced in https://github.com/wesnoth/haldric/commit/a973f35dfe843931b7720caf8a4360bd9cfd8c08 - tiles transitions stopped showing in game scene. My changes aimed to update transitions only where it was needed when adding tile in map editor, however it only worked when new tiles were added to the map. In Game all tiles are added at scenario load so no transitions were updated at all - to fix I made a change to update all transitions during Transitions.gd initialization (previous optimization still works if new tiles are added to map).

Proof it works again:
![image](https://user-images.githubusercontent.com/9964886/68714144-9969ad00-059f-11ea-9255-51013b604b02.png)
