### PR TITLE
Implements basic recruitment

### DIFF
--- a/graphics/shaders_visual/cell_highlight.tres
+++ b/graphics/shaders_visual/cell_highlight.tres
@@ -1,0 +1,67 @@
+[gd_resource type="VisualShader" load_steps=4 format=2]
+
+[sub_resource type="VisualShaderNodeInput" id=2]
+input_name = "uv"
+
+[sub_resource type="VisualShaderNodeTexture" id=3]
+source = 2
+
+[sub_resource type="VisualShaderNodeColorUniform" id=20]
+uniform_name = "BlendColor2"
+
+[resource]
+code = "shader_type canvas_item;
+render_mode unshaded;
+
+uniform vec4 BlendColor2 : hint_color;
+
+
+
+void vertex() {
+// Output:0
+
+}
+
+void fragment() {
+// ColorUniform:49
+	vec3 n_out49p0;
+	float n_out49p1;
+	n_out49p0 = BlendColor2.rgb;
+	n_out49p1 = BlendColor2.a;
+
+// Input:21
+	vec3 n_out21p0;
+	n_out21p0 = vec3(UV,0.0);
+
+// Texture:22
+	vec3 n_out22p0;
+	float n_out22p1;
+	{
+		vec4 _tex_read = texture( TEXTURE , n_out21p0.xy );
+		n_out22p0 = _tex_read.rgb;
+		n_out22p1 = _tex_read.a;
+	}
+
+// Output:0
+	COLOR.rgb = n_out49p0;
+	COLOR.a = n_out22p1;
+
+}
+
+void light() {
+// Output:0
+
+}
+"
+graph_offset = Vector2( 130.242, -177.72 )
+mode = 1
+flags/light_only = false
+flags/unshaded = true
+nodes/fragment/0/position = Vector2( 1100, 400 )
+nodes/fragment/21/node = SubResource( 2 )
+nodes/fragment/21/position = Vector2( 180, 600 )
+nodes/fragment/22/node = SubResource( 3 )
+nodes/fragment/22/position = Vector2( 400, 580 )
+nodes/fragment/49/node = SubResource( 20 )
+nodes/fragment/49/position = Vector2( 840, 260 )
+nodes/fragment/connections = PoolIntArray( 21, 0, 22, 0, 22, 1, 0, 1, 49, 0, 0, 0 )

--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -83,6 +83,8 @@ func _ready() -> void:
 	HUD.connect("turn_end_pressed", self, "_on_turn_end_pressed")
 	# warning-ignore:return_value_discarded
 	HUD.connect("unit_recruitment_requested", self, "_on_unit_recruitment_requested")
+	# warning-ignore:return_value_discarded
+	HUD.connect("unit_recruitment_menu_requested", self, "_on_unit_recruitment_menu_requested")
 
 	if scenario.sides.get_child_count() > 0:
 		_set_side(scenario.sides.get_child(0))
@@ -260,3 +262,6 @@ func _on_unit_recruitment_requested(unit_type : UnitType) -> void:
 		# no possibility to recruit to surronding locations
 		print("[WARN] Recruitment was attmepted but there were no allowed spots for it")
 	HUD.set_recruitment_allowed(current_unit.location.can_recruit_from())
+
+func _on_unit_recruitment_menu_requested():
+	HUD.open_recruitment_menu(current_side.recruitable_unit_types)

--- a/source/interface/hud/GameHUD.gd
+++ b/source/interface/hud/GameHUD.gd
@@ -1,11 +1,17 @@
 extends CanvasLayer
 
+const Archer := preload("res://data/units/elves-wood/ElvishArcher.tscn")
+const Ranger := preload("res://data/units/elves-wood/ElvishRanger.tscn")
+const Scout := preload("res://data/units/elves-wood/Scout.tscn")
+
 signal turn_end_pressed
 signal unit_advancement_selected(unit, unit_id)
 signal attack_selected(attack, target)
+signal unit_recruitment_requested
 
 onready var advancement_popup := $AdvancementPopup as AdvancementPopup
 onready var attack_popup := $AttackPopup as AttackPopup
+onready var recruitment_popup := $RecruitmentPopup as Popup
 
 onready var unit_panel := $UnitPanel as Control
 onready var side_panel := $SidePanel as Control
@@ -16,6 +22,8 @@ onready var pause_menu := $PauseMenu as Control
 func _ready() -> void:
 	advancement_popup.connect("advancement_selected", self, "_on_advancement_selected")
 	attack_popup.connect("attack_selected", self, "_on_attack_selected")
+	unit_panel.connect("recruitment_popup_requested", self, "_on_recruitment_popup_requested")
+	recruitment_popup.connect("unit_recruitment_requested", self, "_on_unit_recruitment_requested")
 
 func show_advancement_popup(unit: Unit) -> void:
 	advancement_popup.popup_unit(unit)
@@ -30,6 +38,9 @@ func update_time_info(time: Time) -> void:
 
 func update_unit_info(unit : Unit) -> void:
 	unit_panel.update_unit(unit)
+	
+func set_recruitment_allowed(is_allowed : bool) -> void:
+	unit_panel.set_recruitment_allowed(is_allowed)
 
 func update_side_info(scenario : Scenario, side : Side) -> void:
 	side_panel.update_side(scenario, side)
@@ -48,3 +59,9 @@ func _on_Back_pressed() -> void:
 
 func _on_TurnEndPanel_turn_end_pressed() -> void:
 	emit_signal("turn_end_pressed")
+
+func _on_recruitment_popup_requested() -> void:
+	recruitment_popup.show_popup([Archer.instance(), Ranger.instance(), Scout.instance()])
+
+func _on_unit_recruitment_requested(unit_type : UnitType):
+	emit_signal("unit_recruitment_requested", unit_type)

--- a/source/interface/hud/GameHUD.gd
+++ b/source/interface/hud/GameHUD.gd
@@ -1,13 +1,10 @@
 extends CanvasLayer
 
-const Archer := preload("res://data/units/elves-wood/ElvishArcher.tscn")
-const Ranger := preload("res://data/units/elves-wood/ElvishRanger.tscn")
-const Scout := preload("res://data/units/elves-wood/Scout.tscn")
-
 signal turn_end_pressed
 signal unit_advancement_selected(unit, unit_id)
 signal attack_selected(attack, target)
 signal unit_recruitment_requested
+signal unit_recruitment_menu_requested
 
 onready var advancement_popup := $AdvancementPopup as AdvancementPopup
 onready var attack_popup := $AttackPopup as AttackPopup
@@ -38,7 +35,7 @@ func update_time_info(time: Time) -> void:
 
 func update_unit_info(unit : Unit) -> void:
 	unit_panel.update_unit(unit)
-	
+
 func set_recruitment_allowed(is_allowed : bool) -> void:
 	unit_panel.set_recruitment_allowed(is_allowed)
 
@@ -61,7 +58,10 @@ func _on_TurnEndPanel_turn_end_pressed() -> void:
 	emit_signal("turn_end_pressed")
 
 func _on_recruitment_popup_requested() -> void:
-	recruitment_popup.show_popup([Archer.instance(), Ranger.instance(), Scout.instance()])
+	emit_signal("unit_recruitment_menu_requested")
 
-func _on_unit_recruitment_requested(unit_type : UnitType):
+func open_recruitment_menu(unit_types : Array) -> void:
+	recruitment_popup.show_popup(unit_types)
+
+func _on_unit_recruitment_requested(unit_type : UnitType) -> void:
 	emit_signal("unit_recruitment_requested", unit_type)

--- a/source/interface/hud/GameHUD.gd
+++ b/source/interface/hud/GameHUD.gd
@@ -64,5 +64,5 @@ func _on_recruitment_popup_requested() -> void:
 func open_recruitment_menu(unit_types : Array) -> void:
 	recruitment_popup.show_popup(unit_types)
 
-func _on_unit_recruitment_requested(unit_type : UnitType) -> void:
-	emit_signal("unit_recruitment_requested", unit_type)
+func _on_unit_recruitment_requested(unit_type_scene : PackedScene) -> void:
+	emit_signal("unit_recruitment_requested", unit_type_scene)

--- a/source/interface/hud/GameHUD.gd
+++ b/source/interface/hud/GameHUD.gd
@@ -9,6 +9,7 @@ signal unit_recruitment_menu_requested
 onready var advancement_popup := $AdvancementPopup as AdvancementPopup
 onready var attack_popup := $AttackPopup as AttackPopup
 onready var recruitment_popup := $RecruitmentPopup as Popup
+onready var recruitment_button := $RecruitmentButton as Button
 
 onready var unit_panel := $UnitPanel as Control
 onready var side_panel := $SidePanel as Control
@@ -19,7 +20,7 @@ onready var pause_menu := $PauseMenu as Control
 func _ready() -> void:
 	advancement_popup.connect("advancement_selected", self, "_on_advancement_selected")
 	attack_popup.connect("attack_selected", self, "_on_attack_selected")
-	unit_panel.connect("recruitment_popup_requested", self, "_on_recruitment_popup_requested")
+	recruitment_button.connect("pressed", self, "_on_recruitment_popup_requested")
 	recruitment_popup.connect("unit_recruitment_requested", self, "_on_unit_recruitment_requested")
 
 func show_advancement_popup(unit: Unit) -> void:
@@ -37,7 +38,7 @@ func update_unit_info(unit : Unit) -> void:
 	unit_panel.update_unit(unit)
 
 func set_recruitment_allowed(is_allowed : bool) -> void:
-	unit_panel.set_recruitment_allowed(is_allowed)
+	recruitment_button.visible = is_allowed
 
 func update_side_info(scenario : Scenario, side : Side) -> void:
 	side_panel.update_side(scenario, side)

--- a/source/interface/hud/GameHUD.tscn
+++ b/source/interface/hud/GameHUD.tscn
@@ -86,6 +86,7 @@ margin_right = -760.0
 margin_bottom = -240.0
 
 [node name="RecruitmentButton" type="Button" parent="."]
+visible = false
 margin_left = 105.233
 margin_top = 35.8749
 margin_right = 332.233

--- a/source/interface/hud/GameHUD.tscn
+++ b/source/interface/hud/GameHUD.tscn
@@ -84,4 +84,14 @@ margin_left = 760.0
 margin_top = 240.0
 margin_right = -760.0
 margin_bottom = -240.0
+
+[node name="RecruitmentButton" type="Button" parent="."]
+margin_left = 105.233
+margin_top = 35.8749
+margin_right = 332.233
+margin_bottom = 141.875
+text = "Recruit"
+__meta__ = {
+"_edit_use_anchors_": false
+}
 [connection signal="turn_end_pressed" from="TurnEndWidget" to="." method="_on_TurnEndPanel_turn_end_pressed"]

--- a/source/interface/hud/GameHUD.tscn
+++ b/source/interface/hud/GameHUD.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://source/interface/hud/UnitPanel.tscn" type="PackedScene" id=1]
 [ext_resource path="res://source/interface/hud/AttackPopup.tscn" type="PackedScene" id=2]
@@ -9,6 +9,7 @@
 [ext_resource path="res://source/interface/hud/AdvancementPopup.tscn" type="PackedScene" id=7]
 [ext_resource path="res://source/interface/hud/SidePanel.tscn" type="PackedScene" id=8]
 [ext_resource path="res://source/interface/hud/GameHUD.gd" type="Script" id=9]
+[ext_resource path="res://source/interface/hud/RecruitmentPopup.tscn" type="PackedScene" id=10]
 
 [node name="HUD" type="CanvasLayer"]
 layer = 2
@@ -77,4 +78,10 @@ margin_left = -3.0
 margin_top = -3.0
 margin_right = 3.0
 margin_bottom = 3.0
+
+[node name="RecruitmentPopup" parent="." instance=ExtResource( 10 )]
+margin_left = 760.0
+margin_top = 240.0
+margin_right = -760.0
+margin_bottom = -240.0
 [connection signal="turn_end_pressed" from="TurnEndWidget" to="." method="_on_TurnEndPanel_turn_end_pressed"]

--- a/source/interface/hud/RecruitmentPopup.gd
+++ b/source/interface/hud/RecruitmentPopup.gd
@@ -1,0 +1,28 @@
+extends Popup
+
+signal unit_recruitment_requested
+
+const UnitRecruitmentCard = preload("res://source/interface/hud/UnitRecruitmentCard.tscn")
+onready var units_container := $UnitsListContainer as VBoxContainer
+
+var initialized := false
+
+func _ready():
+	connect("popup_hide", self, "_on_popup_hide")
+
+func show_popup(unit_types : Array) -> void:
+	for unit_type in unit_types:
+		var card := UnitRecruitmentCard.instance()
+		card.connect("unit_recruitment_card_clicked", self, "_on_unit_recruitment_card_clicked")
+		units_container.add_child(card)
+		card.initialize(unit_type)
+	popup()
+
+func _on_unit_recruitment_card_clicked(unit_type : UnitType) -> void:
+	emit_signal("unit_recruitment_requested", unit_type)
+
+	hide()
+
+func _on_popup_hide():
+	for child in units_container.get_children():
+		child.queue_free()

--- a/source/interface/hud/RecruitmentPopup.gd
+++ b/source/interface/hud/RecruitmentPopup.gd
@@ -10,16 +10,16 @@ var initialized := false
 func _ready():
 	connect("popup_hide", self, "_on_popup_hide")
 
-func show_popup(unit_types : Array) -> void:
-	for unit_type in unit_types:
+func show_popup(unit_type_scenes : Array) -> void:
+	for unit_type_scene in unit_type_scenes:
 		var card := UnitRecruitmentCard.instance()
 		card.connect("unit_recruitment_card_clicked", self, "_on_unit_recruitment_card_clicked")
 		units_container.add_child(card)
-		card.initialize(unit_type)
+		card.initialize(unit_type_scene)
 	popup()
 
-func _on_unit_recruitment_card_clicked(unit_type : UnitType) -> void:
-	emit_signal("unit_recruitment_requested", unit_type)
+func _on_unit_recruitment_card_clicked(unit_type_scene : PackedScene) -> void:
+	emit_signal("unit_recruitment_requested", unit_type_scene)
 
 	hide()
 

--- a/source/interface/hud/RecruitmentPopup.tscn
+++ b/source/interface/hud/RecruitmentPopup.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://graphics/images/interface/panel.png" type="Texture" id=1]
+[ext_resource path="res://source/interface/hud/RecruitmentPopup.gd" type="Script" id=2]
+
+[node name="RecruitmentPopup" type="Popup"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -1520.0
+margin_bottom = -480.0
+mouse_filter = 1
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TextureRect" type="TextureRect" parent="."]
+margin_right = 400.0
+margin_bottom = 600.0
+texture = ExtResource( 1 )
+expand = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="UnitsListContainer" type="VBoxContainer" parent="."]
+margin_left = 150.0
+margin_right = 400.0
+margin_bottom = 600.0
+custom_constants/separation = 100
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/source/interface/hud/UnitPanel.gd
+++ b/source/interface/hud/UnitPanel.gd
@@ -28,7 +28,6 @@ signal recruitment_popup_requested
 
 func _ready() -> void:
 	unit_window.connect("request_scroll_to_unit", self, "_focus_camera_on_selected_unit")
-	recruitment_button.connect("button_up", self, "_on_recruitment_button_up")
 	unit_camera.position = Vector2(200, 200)
 	clear_unit()
 
@@ -73,9 +72,6 @@ func update_unit(target: Unit) -> void:
 
 	for attack in unit.type.get_attacks():
 		_add_attack_plate(attack)
-
-func set_recruitment_allowed(is_allowed : bool):
-	recruitment_button.visible = is_allowed
 
 func clear_unit() -> void:
 	unit = null

--- a/source/interface/hud/UnitPanel.gd
+++ b/source/interface/hud/UnitPanel.gd
@@ -24,8 +24,11 @@ onready var attacks := $MarginContainer/VBoxContainer/Attacks as VBoxContainer
 
 onready var tween := $Tween as Tween
 
+signal recruitment_popup_requested
+
 func _ready() -> void:
 	unit_window.connect("request_scroll_to_unit", self, "_focus_camera_on_selected_unit")
+	recruitment_button.connect("button_up", self, "_on_recruitment_button_up")
 	unit_camera.position = Vector2(200, 200)
 	clear_unit()
 
@@ -70,6 +73,9 @@ func update_unit(target: Unit) -> void:
 
 	for attack in unit.type.get_attacks():
 		_add_attack_plate(attack)
+
+func set_recruitment_allowed(is_allowed : bool):
+	recruitment_button.visible = is_allowed
 
 func clear_unit() -> void:
 	unit = null
@@ -132,3 +138,6 @@ func _get_cyan_to_white_color(value: int) -> Color:
 func _get_light_to_dark_brown(value: int) -> Color:
 	var mod = float(value) * 0.01
 	return Color(0.48 * mod + 0.1, 0.4 * mod + 0.1, 0.35 * mod + 0.1)
+
+func _on_recruitment_button_up() -> void:
+	emit_signal("recruitment_popup_requested")

--- a/source/interface/hud/UnitRecruitmentCard.gd
+++ b/source/interface/hud/UnitRecruitmentCard.gd
@@ -5,14 +5,16 @@ signal unit_recruitment_card_clicked
 onready var avatar := $UnitRecruitmentCardHbox/Avatar as TextureRect
 onready var name_label := $UnitRecruitmentCardHbox/VBoxContainer/NameLabel as Label
 onready var cost_label := $UnitRecruitmentCardHbox/VBoxContainer/HBoxContainer/CostLabel as Label
-var unit_type : Node
+var unit_type_scene: PackedScene
 
-func initialize(unit_type : UnitType) -> void:
+func initialize(unit_type_scene : PackedScene) -> void:
+	self.unit_type_scene = unit_type_scene
+
+	var unit_type = unit_type_scene.instance()
 	avatar.texture = unit_type.find_node("Sprite").texture
-	self.unit_type = unit_type
 	name_label.text = unit_type.name
 	cost_label.text = str(unit_type.cost)
 
 func _gui_input(event : InputEvent) -> void:
 	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and event.is_pressed():
-		emit_signal("unit_recruitment_card_clicked", unit_type)
+		emit_signal("unit_recruitment_card_clicked", unit_type_scene)

--- a/source/interface/hud/UnitRecruitmentCard.gd
+++ b/source/interface/hud/UnitRecruitmentCard.gd
@@ -1,0 +1,18 @@
+extends Control
+
+signal unit_recruitment_card_clicked
+
+onready var avatar := $UnitRecruitmentCardHbox/Avatar as TextureRect
+onready var name_label := $UnitRecruitmentCardHbox/VBoxContainer/NameLabel as Label
+onready var cost_label := $UnitRecruitmentCardHbox/VBoxContainer/HBoxContainer/CostLabel as Label
+var unit_type : Node
+
+func initialize(unit_type : UnitType) -> void:
+	avatar.texture = unit_type.find_node("Sprite").texture
+	self.unit_type = unit_type
+	name_label.text = unit_type.name
+	cost_label.text = str(unit_type.cost)
+
+func _gui_input(event : InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and event.is_pressed():
+		emit_signal("unit_recruitment_card_clicked", unit_type)

--- a/source/interface/hud/UnitRecruitmentCard.tscn
+++ b/source/interface/hud/UnitRecruitmentCard.tscn
@@ -57,7 +57,6 @@ size_flags_vertical = 3
 [node name="GoldIcon" type="TextureRect" parent="UnitRecruitmentCardHbox/VBoxContainer/HBoxContainer"]
 margin_right = 25.0
 margin_bottom = 45.0
-rect_scale = Vector2( 1.5, 1.5 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.3
 texture = ExtResource( 4 )

--- a/source/interface/hud/UnitRecruitmentCard.tscn
+++ b/source/interface/hud/UnitRecruitmentCard.tscn
@@ -1,0 +1,88 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://graphics/images/units/undead/ghost-s-2.png" type="Texture" id=1]
+[ext_resource path="res://graphics/images/interface/panels.png" type="Texture" id=2]
+[ext_resource path="res://source/interface/hud/UnitRecruitmentCard.gd" type="Script" id=3]
+[ext_resource path="res://graphics/images/interface/icons/gold.png" type="Texture" id=4]
+[ext_resource path="res://graphics/fonts/Lato18.tres" type="DynamicFont" id=5]
+
+[node name="UnitRecruitmentCard" type="Control"]
+margin_left = -1.0
+margin_right = 199.0
+margin_bottom = 80.0
+script = ExtResource( 3 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="UnitRecruitmentCardHbox" type="HBoxContainer" parent="."]
+margin_right = 200.0
+margin_bottom = 80.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Avatar" type="TextureRect" parent="UnitRecruitmentCardHbox"]
+margin_right = 72.0
+margin_bottom = 80.0
+mouse_filter = 2
+texture = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UnitRecruitmentCardHbox"]
+margin_left = 80.0
+margin_right = 200.0
+margin_bottom = 80.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="NameLabel" type="Label" parent="UnitRecruitmentCardHbox/VBoxContainer"]
+margin_right = 120.0
+margin_bottom = 27.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.6
+custom_fonts/font = ExtResource( 5 )
+text = "unit_name"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="UnitRecruitmentCardHbox/VBoxContainer"]
+margin_top = 35.0
+margin_right = 120.0
+margin_bottom = 80.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="GoldIcon" type="TextureRect" parent="UnitRecruitmentCardHbox/VBoxContainer/HBoxContainer"]
+margin_right = 25.0
+margin_bottom = 45.0
+rect_scale = Vector2( 1.5, 1.5 )
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.3
+texture = ExtResource( 4 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CostLabel" type="Label" parent="UnitRecruitmentCardHbox/VBoxContainer/HBoxContainer"]
+margin_left = 33.0
+margin_right = 120.0
+margin_bottom = 45.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_fonts/font = ExtResource( 5 )
+text = "cost"
+
+[node name="Border" type="NinePatchRect" parent="."]
+margin_right = 200.0
+margin_bottom = 80.0
+texture = ExtResource( 2 )
+region_rect = Rect2( 40, 0, 20, 20 )
+patch_margin_left = 4
+patch_margin_top = 4
+patch_margin_right = 4
+patch_margin_bottom = 4
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/source/scenario/Scenario.gd
+++ b/source/scenario/Scenario.gd
@@ -31,28 +31,31 @@ func initialize() -> void:
 func get_side(side_number: int) -> Side:
 	return sides.get_child(side_number - 1) as Side
 
-func add_unit(side_number: int, unit_id: String, x: int, y: int) -> void:
-	var side: Side = get_side(side_number)
-
-	if side == null:
-		print("Invalid side number %d" % side_number)
-		return
-
-	var unit_type: PackedScene = Registry.units[unit_id]
-
-	if unit_type == null:
-		print("Invalid unit type '%s'" % unit_id)
-		return
-
+func add_unit_with_loaded_data(side: Side, unit_type: UnitType, target_location : Location) -> void:
 	var unit = Wesnoth.Unit.instance()
 	unit.connect("experienced", self, "_on_unit_experienced")
 	unit.connect("moved", self, "_on_unit_moved")
 	unit.connect("move_finished", self, "_on_unit_move_finished")
 
-	unit.type = unit_type.instance()
+	unit.type = unit_type
 
 	side.add_unit(unit)
-	unit.place_at(map.get_location(Vector2(x, y)))
+	unit.place_at(target_location)
+
+func add_unit(side_number: int, unit_id: String, x: int, y: int) -> void:
+	var unit_type: PackedScene = Registry.units[unit_id]
+	if unit_type == null:
+		print("Invalid unit type '%s'" % unit_id)
+		return
+	
+	var side: Side = get_side(side_number)
+
+	if side == null:
+		print("Invalid side number %d" % side_number)
+		return
+	
+	add_unit_with_loaded_data(side, unit_type.instance(), map.get_location(Vector2(x, y)))
+
 
 func get_village_count() -> int:
 	return map.get_village_count()

--- a/source/scenario/Side.gd
+++ b/source/scenario/Side.gd
@@ -46,7 +46,7 @@ onready var number := get_index() + 1
 onready var units = $Units as Node2D
 onready var flags = $Flags as Node2D
 
-var recruitable_unit_types : Array
+var recruitable_unit_type_scenes : Array
 
 func _ready() -> void:
 	Event.connect("turn_refresh", self, "_on_turn_refresh")
@@ -59,9 +59,8 @@ func _ready() -> void:
 
 	_calculate_upkeep()
 	_calculate_income()
-	recruitable_unit_types = [Archer.instance(), Ranger.instance(), Scout.instance()]
+	recruitable_unit_type_scenes = [Archer, Ranger, Scout]
 
-# :Unit
 func add_unit(unit) -> void:
 	"""
 	Adds the specified unit object and sets it to belong to this side

--- a/source/scenario/Side.gd
+++ b/source/scenario/Side.gd
@@ -3,6 +3,10 @@ class_name Side
 
 const Flag = preload("res://source/game/Flag.tscn")
 
+const Archer := preload("res://data/units/elves-wood/ElvishArcher.tscn")
+const Ranger := preload("res://data/units/elves-wood/ElvishRanger.tscn")
+const Scout := preload("res://data/units/elves-wood/Scout.tscn")
+
 const INCOME_PER_VILLAGE = 1 # How much gold extra each village provides
 
 const HEAL_ON_VILLAGE = 8 # Each unit starting its turn in a village heals this amount per turn
@@ -42,6 +46,8 @@ onready var number := get_index() + 1
 onready var units = $Units as Node2D
 onready var flags = $Flags as Node2D
 
+var recruitable_unit_types : Array
+
 func _ready() -> void:
 	Event.connect("turn_refresh", self, "_on_turn_refresh")
 
@@ -53,6 +59,7 @@ func _ready() -> void:
 
 	_calculate_upkeep()
 	_calculate_income()
+	recruitable_unit_types = [Archer.instance(), Ranger.instance(), Scout.instance()]
 
 # :Unit
 func add_unit(unit) -> void:

--- a/source/scenario/Side.gd
+++ b/source/scenario/Side.gd
@@ -168,3 +168,9 @@ func _on_turn_refresh(turn: int, side: int) -> void:
 	"""
 	if self.number == side:
 		_turn_refresh(turn == 1)
+
+func try_spending_gold(amount : int) -> bool:
+	if amount > gold || amount < 0:
+		return false
+	gold -= amount
+	return true

--- a/source/scenario/map/Location.gd
+++ b/source/scenario/map/Location.gd
@@ -71,3 +71,15 @@ func get_adjacent_locations() -> Array:
 		if neighbor:
 			neighbor_locations.append(neighbor)
 	return neighbor_locations
+
+func can_recruit_from():
+	return terrain.recruit_from && get_adjacent_free_recruitment_location() != null
+
+func get_adjacent_free_recruitment_location() -> Location:
+	for target_location in get_adjacent_locations():
+		if target_location._can_recruit_to():
+			return target_location
+	return null
+
+func _can_recruit_to():
+	return terrain.recruit_onto && unit == null

--- a/source/scenario/map/Location.gd
+++ b/source/scenario/map/Location.gd
@@ -6,8 +6,6 @@ It contains information such as its coordinates on a hex grid, its terrain and a
 
 const OFFSET = Vector2(36, 36)
 
-
-
 var id := 0
 
 var position := Vector2() # Centered position of cell on the tilemap in Axial coordinates
@@ -72,14 +70,15 @@ func get_adjacent_locations() -> Array:
 			neighbor_locations.append(neighbor)
 	return neighbor_locations
 
-func can_recruit_from():
-	return terrain.recruit_from && get_adjacent_free_recruitment_location() != null
+func can_recruit_from() -> bool:
+	return terrain.recruit_from && !get_adjacent_free_recruitment_locations().empty()
 
-func get_adjacent_free_recruitment_location() -> Location:
+func get_adjacent_free_recruitment_locations() -> Array:
+	var locations := []
 	for target_location in get_adjacent_locations():
 		if target_location._can_recruit_to():
-			return target_location
-	return null
+			locations.append(target_location)
+	return locations
 
 func _can_recruit_to():
 	return terrain.recruit_onto && unit == null

--- a/source/scenario/map/Map.gd
+++ b/source/scenario/map/Map.gd
@@ -28,6 +28,7 @@ var ZOC_tiles := {} # Hexes exert a Zone of Control (because a unit is on them)
 
 onready var overlay := $Overlay as TileMap
 onready var cover := $Cover as TileMap
+onready var highlight := $Highlight as TileMap
 onready var transitions := $Transitions as Transitions
 
 onready var border := $MapBorder # The hexes which are renderred but not playable
@@ -393,7 +394,7 @@ func display_reachable_for(reachable_locs: Dictionary) -> void:
 	# Nothing to show, hide the map and bail.
 	if reachable_locs.empty():
 		cover.hide()
-		return;
+		return
 
 	# Punch out visible area
 	for loc in reachable_locs:
@@ -401,12 +402,31 @@ func display_reachable_for(reachable_locs: Dictionary) -> void:
 
 	cover.show()
 
+func update_highlight(location_to_highlight : Array) -> void:
+	# clear any previous highlight
+	clear_highlight()
+
+	if location_to_highlight.empty():
+		return
+
+	for location in location_to_highlight:
+		highlight.set_cellv(location.cell, void_tile)
+
+	highlight.show()
+
+func clear_highlight() -> void:
+	for y in rect.size.y:
+		for x in rect.size.x:
+			highlight.set_cell(x, y, -1)
+	highlight.hide()
+
 func reset_if_empty(cell: Vector2, clear_overlay: bool = false) -> void:
 	if get_cellv(cell) == INVALID_CELL:
 		set_cellv(cell, default_tile)
 
 		if clear_overlay:
 			overlay.set_cellv(cell, INVALID_CELL)
+
 func debug():
 	$Hover/HexDebug.visible = not $Hover/HexDebug.visible
 

--- a/source/scenario/map/Map.tscn
+++ b/source/scenario/map/Map.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://graphics/tilesets/terrain.tres" type="TileSet" id=1]
 [ext_resource path="res://source/scenario/map/Map.gd" type="Script" id=2]
@@ -7,8 +7,13 @@
 [ext_resource path="res://graphics/tilesets/void.tres" type="TileSet" id=5]
 [ext_resource path="res://source/interface/draw/MapBorder.tscn" type="PackedScene" id=6]
 [ext_resource path="res://graphics/images/interface/misc/hover-hex.png" type="Texture" id=7]
+[ext_resource path="res://graphics/shaders_visual/cell_highlight.tres" type="Shader" id=8]
 
-[sub_resource type="ShaderMaterial" id=1]
+[sub_resource type="ShaderMaterial" id=2]
+shader = ExtResource( 8 )
+shader_param/BlendColor2 = Color( 0.054902, 0.976471, 0, 1 )
+
+[sub_resource type="ShaderMaterial" id=3]
 shader = ExtResource( 4 )
 shader_param/BlendColor = Color( 0.3, 0.59, 0.11, 1 )
 shader_param/Blur = 0.2
@@ -34,9 +39,16 @@ cell_size = Vector2( 54, 72 )
 cell_half_offset = 1
 format = 1
 
+[node name="Highlight" type="TileMap" parent="."]
+material = SubResource( 2 )
+tile_set = ExtResource( 5 )
+cell_size = Vector2( 54, 72 )
+cell_half_offset = 1
+format = 1
+
 [node name="Cover" type="TileMap" parent="."]
 visible = false
-material = SubResource( 1 )
+material = SubResource( 3 )
 z_index = 100
 tile_set = ExtResource( 5 )
 cell_size = Vector2( 54, 72 )
@@ -62,7 +74,8 @@ margin_top = -10.4554
 margin_right = 84.7766
 margin_bottom = 14.5446
 __meta__ = {
-"_edit_group_": true
+"_edit_group_": true,
+"_edit_use_anchors_": false
 }
 
 [node name="HexCubeLabel" type="Label" parent="Hover/HexDebug"]


### PR DESCRIPTION
Hello, this is PR that implements basic recruitment mechanic. It is basic version of mechanic and some things are hardcoded, gui is very minimalistic, but well, it works and can be improved upon, which I will gladly do in later PRs. 

Closes part of  #58

### **How it works:**
1. When any unit (no idea of leader is present yet) steps on terrain that has recruit_from set to true (such as a keep), recruit button appears in some random place in HUD, tbd how it will look finally.
![image](https://user-images.githubusercontent.com/9964886/70469684-d0ad7a00-1ac9-11ea-8b8b-42bcfa215379.png)

As discussed on discord we are not going to go for context menu for now (or at all)

2. Then when button is clicked list of units for recruitment is presented in popup:
![image](https://user-images.githubusercontent.com/9964886/69481045-d2124d80-0e0d-11ea-88a7-6e7bf1a36f4b.png)

Popup is made bigger to facilitate unit summary that probably will be part of this view (as in wesnoth)

3. When unit from the list is selected game moves into 'location selection mode' where tiles available for recruitment are highlighted. Highlight looks like shit but maybe it will work for now.
![image](https://user-images.githubusercontent.com/9964886/70470673-dd32d200-1acb-11ea-92e8-1a7118187dfb.png)

4. When we click selected tile unit is recruited there
![image](https://user-images.githubusercontent.com/9964886/70470713-f20f6580-1acb-11ea-98c2-187ca8377a16.png)


5. When there is no space to recruit new unit recruitment button does not appear

6. Units cost gold - if there is not enough unit will not be recruited

### **Known issues and things TODO**

1. No leader implemented - every unit can recruit
2. ~~List of units for recruitment is hardcoded in some pretty random place - needs to be moved to config~~ Now it is hardcoded in Side, all we need to do is load Side config from file (not done at all at the moment) - will need separate PR probably
3. If there is no enough gold for recruitment gui will not grey out or otherwise indicate that (though recruitment will not happen)
4. Recruitment popup looks like shit - some design is needed as to what should be the final look - since I don't know I did not waste time to make it look nice
5. Recruited units start with full movement - easy to fix but I wanted to tackle one allowed movement vision bug before I do this
6. Can only recruit to surrounding tiles - in wesnoth broader range of tiles was considered (I think all tiles adjoining to recruitment center and tiles adjoining to them were considered).
7. Whole mechanic feels very weird - you need to move unit to keep, then click it again so it gains focus, then you have to click recruit button (all the time red path trail is following your cursor). Looking for suggestions how to improve here.
8. ~~It is not possible to select tile to recruit to~~
9. When in tile selection mode showing transparent model of unit next to mouse location would be nice feat

