### PR TITLE
Don't draw area of view outside of minimap

### DIFF
--- a/source/interface/hud/Minimap.tscn
+++ b/source/interface/hud/Minimap.tscn
@@ -8,6 +8,7 @@
 [node name="Minimap" type="Control"]
 margin_right = 240.0
 margin_bottom = 180.0
+rect_clip_content = true
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false


### PR DESCRIPTION
Sets clip content on minimap so that are of view is not drawn outside minimap boundaries.
![image](https://user-images.githubusercontent.com/9964886/69482764-d2b3df80-0e1f-11ea-9dc3-18751da75e3a.png)

Thanks for bitron for suggestion