### PR TITLE
Grants exp at unit kill

### DIFF
--- a/data/units/undead/VampireBat.tscn
+++ b/data/units/undead/VampireBat.tscn
@@ -30,7 +30,6 @@ tracks/0/keys = {
 id = "Vampire Bat"
 race = "bat"
 alignment = "chaotic"
-level = 0
 cost = 13
 health = 16
 moves = 9

--- a/source/unit/Attack.gd
+++ b/source/unit/Attack.gd
@@ -11,7 +11,7 @@ export var icon : StreamTexture = null
 onready var specials := get_children()
 
 func execute_before_turn(user, target):
-	if not specials.empty():
+	if specials and not specials.empty():
 		for child in specials:
 			if child.has_method("execute_before_turn_to_enemy"):
 				child.execute_before_turn_to_enemy(target)
@@ -21,7 +21,7 @@ func execute_before_turn(user, target):
 				child.execute_before_turn_on_weapon(self)
 
 func execute_each_turn(user, target):
-	if not specials.empty():
+	if specials and not specials.empty():
 		for child in specials:
 			if child.has_method("execute_each_turn_to_enemy"):
 				child.execute_each_turn_to_enemy(target)
@@ -31,7 +31,7 @@ func execute_each_turn(user, target):
 				child.execute_each_turn_on_weapon(self)
 
 func execute_end_turn(user, target):
-	if not specials.empty():
+	if specials and not specials.empty():
 		for child in specials:
 			if child.has_method("execute_end_turn_to_enemy"):
 				child.execute_end_turn_to_enemy(target)


### PR DESCRIPTION
This solves issue when fighting and exp systems were not connected, now exp is granted to attacker at kill, formula for amount of exp is `killedUnitLevel * 8`. 

Also solves issue where unit level was not incremented on levelup.

Also solves issue where np was thrown when attacking unit with attack type that defending unit did not have.

Also solves bug where units with 0hp were not killed.