### PR TITLE
Update shown unit range after move

### DIFF
--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -231,6 +231,7 @@ func _on_unit_moved(unit: Unit, location: Location) -> void:
 func _on_unit_move_finished(unit: Unit, location: Location, halted: bool) -> void:
 	_grab_village(unit, location)
 	unit.set_reachable()
+	scenario.map.display_reachable_for(unit.reachable)
 	if halted:
 		_set_current_unit(unit)
 


### PR DESCRIPTION
This solves issue when range of movement shown on map was not correctly updated after movement.

Before: https://gfycat.com/adolescentcleanhectorsdolphin

After: https://gfycat.com/mediumaccurategonolek
