### PR TITLE
Reserve recruitment action only for leaders

### DIFF
--- a/data/scenarios/test.gd
+++ b/data/scenarios/test.gd
@@ -2,7 +2,7 @@ extends Scenario
 
 func _start() -> void:
 	add_unit(1, "Elvish Archer", 4, 4)
-	add_unit(1, "Elvish Scout", 5, 4)
+	add_unit(1, "Elvish Scout", 5, 4, true)
 	add_unit(1, "Elvish Fighter", 6, 4)
 	add_unit(1, "Elvish Shaman", 7, 4)
 

--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -156,10 +156,13 @@ func _set_current_unit(value: Unit) -> void:
 
 	if current_unit:
 		scenario.map.display_reachable_for(current_unit.reachable)
-		HUD.set_recruitment_allowed(current_unit.location.can_recruit_from())
+		HUD.set_recruitment_allowed(_can_current_unit_recruit())
 	else:
 		_clear_temp_path()
 		HUD.set_recruitment_allowed(false)
+
+func _can_current_unit_recruit() -> bool:
+	return current_side.is_leader(current_unit) and current_unit.location.can_recruit_from()
 
 func _get_path_for_unit(unit: Unit, new_loc: Location) -> Array:
 	if unit.reachable.has(new_loc):

--- a/source/scenario/Scenario.gd
+++ b/source/scenario/Scenario.gd
@@ -31,7 +31,7 @@ func initialize() -> void:
 func get_side(side_number: int) -> Side:
 	return sides.get_child(side_number - 1) as Side
 
-func add_unit_with_loaded_data(side: Side, unit_type: UnitType, target_location : Location) -> void:
+func add_unit_with_loaded_data(side: Side, unit_type: UnitType, target_location : Location, is_leader := false) -> void:
 	var unit = Wesnoth.Unit.instance()
 	unit.connect("experienced", self, "_on_unit_experienced")
 	unit.connect("moved", self, "_on_unit_moved")
@@ -39,22 +39,22 @@ func add_unit_with_loaded_data(side: Side, unit_type: UnitType, target_location 
 
 	unit.type = unit_type
 
-	side.add_unit(unit)
+	side.add_unit(unit, is_leader)
 	unit.place_at(target_location)
 
-func add_unit(side_number: int, unit_id: String, x: int, y: int) -> void:
+func add_unit(side_number: int, unit_id: String, x: int, y: int, is_leader := false) -> void:
 	var unit_type: PackedScene = Registry.units[unit_id]
 	if unit_type == null:
 		print("Invalid unit type '%s'" % unit_id)
 		return
-	
+
 	var side: Side = get_side(side_number)
 
 	if side == null:
 		print("Invalid side number %d" % side_number)
 		return
-	
-	add_unit_with_loaded_data(side, unit_type.instance(), map.get_location(Vector2(x, y)))
+
+	add_unit_with_loaded_data(side, unit_type.instance(), map.get_location(Vector2(x, y)), is_leader)
 
 
 func get_village_count() -> int:

--- a/source/scenario/Side.gd
+++ b/source/scenario/Side.gd
@@ -61,7 +61,7 @@ func _ready() -> void:
 	_calculate_income()
 	recruitable_unit_type_scenes = [Archer, Ranger, Scout]
 
-func add_unit(unit) -> void:
+func add_unit(unit, is_leader := false) -> void:
 	"""
 	Adds the specified unit object and sets it to belong to this side
 	Also updates gold production (for the GUI)
@@ -69,8 +69,13 @@ func add_unit(unit) -> void:
 	units.add_child(unit)
 	unit.side = self
 	unit.type.sprite.material = unit_shader
+	unit.connect("died", self, "_on_unit_died")
+
 	_calculate_upkeep()
 	_calculate_income()
+
+	if is_leader:
+		leaders.append(unit)
 
 func add_village(loc: Location) -> bool:
 	"""
@@ -101,12 +106,6 @@ func has_village(loc: Location) -> bool:
 	Checks if the side's villages list contains the provided location object
 	"""
 	return villages.has(loc)
-
-# -> Unit
-func get_first_leader():
-	if leaders.size() > 0:
-		return leaders[0]
-	return null
 
 func _calculate_upkeep() -> void:
 	"""
@@ -180,3 +179,12 @@ func try_spending_gold(amount : int) -> bool:
 		return false
 	gold -= amount
 	return true
+
+func is_leader(unit) -> bool:
+	return leaders.find(unit) >= 0
+
+func _on_unit_died(unit : Node) -> void:
+	var idx = leaders.find(unit)
+	if idx >= 0:
+		leaders.remove(idx)
+	unit.queue_free()

--- a/source/unit/Unit.gd
+++ b/source/unit/Unit.gd
@@ -8,6 +8,7 @@ signal experienced(unit)
 signal moved(unit, location)
 signal move_finished(unit, location, halt)
 signal state_changed(new_state)
+signal died(unit)
 
 var side : Side = null
 
@@ -100,7 +101,7 @@ func kill(active_side: bool, attacker: Unit) -> void:
 		attacker.side.viewable_units.erase(attacker)
 	attacker.set_reachable()
 	attacker.experience_current = type.level * 8
-	queue_free()
+	emit_signal("died", self)
 
 func get_movement_cost(loc: Location) -> int:
 	var cost = type.movement.get(loc.terrain.type[0])


### PR DESCRIPTION
Hi,
with this PR only units marked as leaders will be able to recruit units (being leader is hardcoded in scenario startup script). I've changed concept a bit, I don't see a need for `Side` to keep array of all leaders since it keeps track of all units already. `Unit` can know if it is a leader and if `Side` needs to know it's leaders in future it can iterate over units. Having separate array on side creates issue of keeping list of units and array in sync. When leader is killed it was not removed from array of leaders (null is there instead) - before dying `Unit` would need to send signal to `Side` to remove it from array of leaders and only then `queue_free` could be called on `Unit`. Even then I think it is cleaner when unit encapsulates its whole state. If you don't like this change I can go back to previous concept.

Solves part of https://github.com/wesnoth/haldric/issues/58