### PR TITLE
Show move path after halting unit

### DIFF
--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -267,6 +267,7 @@ func _on_unit_move_finished(unit: Unit, location: Location, halted: bool) -> voi
 	scenario.map.display_reachable_for(unit.reachable)
 	if halted:
 		_set_current_unit(unit)
+		_draw_temp_path(_get_path_for_unit(current_unit, scenario.map.get_location_from_mouse()))
 
 func _on_turn_end_pressed() -> void:
 	Event.emit_signal("turn_end", scenario.turn, current_side.number)


### PR DESCRIPTION
Previously when unit was halted path fo field player was hoovering was not displayed. Player needed to make any mouse input (like move) to display the path which felt quite weird. Now this path is visible immediately after halting.