### PR TITLE
Allow loading factions, sides and recruitment data from config. Slightly refactor recruitment code

### DIFF
--- a/data/factions/rebels.tres
+++ b/data/factions/rebels.tres
@@ -8,4 +8,4 @@ id = "rebels"
 name = "Rebels"
 leader = [  ]
 random = [  ]
-recruit = [ "Elvish Archer", "Elvish Fighter", "Evlish Scout", "Evlish Shaman" ]
+recruit = [ "Elvish Archer", "Elvish Fighter", "Elvish Scout", "Elvish Shaman" ]

--- a/data/scenarios/test.gd
+++ b/data/scenarios/test.gd
@@ -6,6 +6,6 @@ func _start() -> void:
 	add_unit(1, "Elvish Fighter", 6, 4)
 	add_unit(1, "Elvish Shaman", 7, 4)
 
-	add_unit(2, "Vampire Bat", 12, 4)
+	add_unit(2, "Vampire Bat", 12, 4, true)
 	add_unit(2, "Ghost", 13, 4)
 	add_unit(2, "Ghost", 15, 4)

--- a/data/scenarios/test.tscn
+++ b/data/scenarios/test.tscn
@@ -7,6 +7,9 @@
 [node name="test" type="Control"]
 mouse_filter = 2
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Schedule" type="Node" parent="."]
 script = ExtResource( 2 )
@@ -14,12 +17,14 @@ script = ExtResource( 2 )
 [node name="Sides" type="Node2D" parent="."]
 
 [node name="Custom1" parent="Sides" instance=ExtResource( 3 )]
+faction = "rebels"
 team_color = "Teal"
 flag_type = "Ragged"
 gold = 125
 fog = true
 
 [node name="Custom2" parent="Sides" instance=ExtResource( 3 )]
+faction = "undead"
 team_color = "Purple"
 flag_type = "Long"
 gold = 125

--- a/data/schedules/two_suns.tres
+++ b/data/schedules/two_suns.tres
@@ -5,4 +5,3 @@
 [resource]
 script = ExtResource( 1 )
 schedule = [ "dawn", "morning", "afternoon", "dusk", "first_watch", "dawn", "morning", "dusk", "first_watch", "second_watch" ]
-

--- a/graphics/shaders_visual/cell_highlight.tres
+++ b/graphics/shaders_visual/cell_highlight.tres
@@ -1,12 +1,12 @@
 [gd_resource type="VisualShader" load_steps=4 format=2]
 
-[sub_resource type="VisualShaderNodeInput" id=2]
+[sub_resource type="VisualShaderNodeInput" id=1]
 input_name = "uv"
 
-[sub_resource type="VisualShaderNodeTexture" id=3]
+[sub_resource type="VisualShaderNodeTexture" id=2]
 source = 2
 
-[sub_resource type="VisualShaderNodeColorUniform" id=20]
+[sub_resource type="VisualShaderNodeColorUniform" id=3]
 uniform_name = "BlendColor2"
 
 [resource]
@@ -58,10 +58,10 @@ mode = 1
 flags/light_only = false
 flags/unshaded = true
 nodes/fragment/0/position = Vector2( 1100, 400 )
-nodes/fragment/21/node = SubResource( 2 )
+nodes/fragment/21/node = SubResource( 1 )
 nodes/fragment/21/position = Vector2( 180, 600 )
-nodes/fragment/22/node = SubResource( 3 )
+nodes/fragment/22/node = SubResource( 2 )
 nodes/fragment/22/position = Vector2( 400, 580 )
-nodes/fragment/49/node = SubResource( 20 )
+nodes/fragment/49/node = SubResource( 3 )
 nodes/fragment/49/position = Vector2( 840, 260 )
 nodes/fragment/connections = PoolIntArray( 21, 0, 22, 0, 22, 1, 0, 1, 49, 0, 0, 0 )

--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -9,7 +9,7 @@ var current_unit: Unit = null setget _set_current_unit
 
 var location_choice_mode := false
 var available_locations := []
-var unit_type_to_recruit : PackedScene
+var unit_type_to_recruit : String
 
 onready var tween = $Tween
 
@@ -79,13 +79,13 @@ func _handle_input_in_normal_mode(event: InputEvent, loc: Location) -> void:
 func _handle_input_in_location_choice_mode(event: InputEvent, mouse_location: Location) -> void:
 	if event.is_action_pressed("mouse_right"):
 		_cancel_location_choice_mode()
-		unit_type_to_recruit = null
+		unit_type_to_recruit = ""
 	if event.is_action_pressed("mouse_left") and mouse_location and available_locations.find(mouse_location) >= 0:
-		var unit_type = unit_type_to_recruit.instance()
+		var unit_type: UnitType = Registry.units[unit_type_to_recruit].instance()
 		if current_side.try_spending_gold(unit_type.cost):
 			scenario.add_unit_with_loaded_data(current_unit.side, unit_type, mouse_location)
 		_cancel_location_choice_mode()
-		unit_type_to_recruit = null
+		unit_type_to_recruit = ""
 
 func _ready() -> void:
 	randomize()
@@ -277,15 +277,15 @@ func _on_turn_end_pressed() -> void:
 	_next_side()
 	Event.emit_signal("turn_refresh", scenario.turn, current_side.number)
 
-func _on_unit_recruitment_requested(unit_type_scene : PackedScene) -> void:
+func _on_unit_recruitment_requested(unit_type_id: String) -> void:
 	var target_locations := current_unit.location.get_adjacent_free_recruitment_locations()
 	_enter_location_choice_mode(target_locations)
 	HUD.set_recruitment_allowed(false)
-	unit_type_to_recruit = unit_type_scene
+	unit_type_to_recruit = unit_type_id
 	_clear_temp_path()
 
 func _on_unit_recruitment_menu_requested():
-	HUD.open_recruitment_menu(current_side.recruitable_unit_type_scenes)
+	HUD.open_recruitment_menu(current_side.recruit)
 
 func _cancel_location_choice_mode() -> void:
 	location_choice_mode = false

--- a/source/global/Registry.gd
+++ b/source/global/Registry.gd
@@ -7,6 +7,7 @@ var campaigns := {}
 var terrain := {}
 var times := {}
 var schedules := {}
+var factions := {}
 
 func _ready() -> void:
 	_make_user_dirs()
@@ -19,6 +20,7 @@ func scan() -> void:
 	_load_campaigns()
 	_load_terrain()
 	_load_times()
+	_load_factions()
 	_load_schedules()
 
 func register_scenario(scenario_id: String, scneario_resource: RScenario, scn_path: String) -> void:
@@ -73,6 +75,12 @@ func _load_schedules() -> void:
 
 	for file_data in Loader.load_dir("res://data/schedules", ["tres", "res"]):
 		schedules[file_data.id] = file_data.data
+
+func _load_factions() -> void:
+	factions.clear()
+
+	for file_data in Loader.load_dir("res://data/factions", ["tres", "res"]):
+		factions[file_data.id] = file_data.data
 
 func _make_user_dirs() -> void:
 	var user_dir := Directory.new()

--- a/source/interface/hud/GameHUD.gd
+++ b/source/interface/hud/GameHUD.gd
@@ -61,8 +61,8 @@ func _on_TurnEndPanel_turn_end_pressed() -> void:
 func _on_recruitment_popup_requested() -> void:
 	emit_signal("unit_recruitment_menu_requested")
 
-func open_recruitment_menu(unit_types : Array) -> void:
-	recruitment_popup.show_popup(unit_types)
+func open_recruitment_menu(unit_types_ids : Array) -> void:
+	recruitment_popup.show_popup(unit_types_ids)
 
-func _on_unit_recruitment_requested(unit_type_scene : PackedScene) -> void:
-	emit_signal("unit_recruitment_requested", unit_type_scene)
+func _on_unit_recruitment_requested(unit_type_id : String) -> void:
+	emit_signal("unit_recruitment_requested", unit_type_id)

--- a/source/interface/hud/RecruitmentPopup.gd
+++ b/source/interface/hud/RecruitmentPopup.gd
@@ -10,16 +10,16 @@ var initialized := false
 func _ready():
 	connect("popup_hide", self, "_on_popup_hide")
 
-func show_popup(unit_type_scenes : Array) -> void:
-	for unit_type_scene in unit_type_scenes:
+func show_popup(unit_types_ids : Array) -> void:
+	for unit_type_id in unit_types_ids:
 		var card := UnitRecruitmentCard.instance()
 		card.connect("unit_recruitment_card_clicked", self, "_on_unit_recruitment_card_clicked")
 		units_container.add_child(card)
-		card.initialize(unit_type_scene)
+		card.initialize(unit_type_id)
 	popup()
 
-func _on_unit_recruitment_card_clicked(unit_type_scene : PackedScene) -> void:
-	emit_signal("unit_recruitment_requested", unit_type_scene)
+func _on_unit_recruitment_card_clicked(unit_type_id : String) -> void:
+	emit_signal("unit_recruitment_requested", unit_type_id)
 
 	hide()
 

--- a/source/interface/hud/UnitRecruitmentCard.gd
+++ b/source/interface/hud/UnitRecruitmentCard.gd
@@ -5,16 +5,15 @@ signal unit_recruitment_card_clicked
 onready var avatar := $UnitRecruitmentCardHbox/Avatar as TextureRect
 onready var name_label := $UnitRecruitmentCardHbox/VBoxContainer/NameLabel as Label
 onready var cost_label := $UnitRecruitmentCardHbox/VBoxContainer/HBoxContainer/CostLabel as Label
-var unit_type_scene: PackedScene
+var unit_type_id: String
 
-func initialize(unit_type_scene : PackedScene) -> void:
-	self.unit_type_scene = unit_type_scene
-
-	var unit_type = unit_type_scene.instance()
+func initialize(unit_type_id: String) -> void:
+	self.unit_type_id = unit_type_id
+	var unit_type: PackedScene = Registry.units[unit_type_id].instance()
 	avatar.texture = unit_type.find_node("Sprite").texture
 	name_label.text = unit_type.name
 	cost_label.text = str(unit_type.cost)
 
 func _gui_input(event : InputEvent) -> void:
 	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and event.is_pressed():
-		emit_signal("unit_recruitment_card_clicked", unit_type_scene)
+		emit_signal("unit_recruitment_card_clicked", unit_type_id)

--- a/source/scenario/Side.gd
+++ b/source/scenario/Side.gd
@@ -3,10 +3,6 @@ class_name Side
 
 const Flag = preload("res://source/game/Flag.tscn")
 
-const Archer := preload("res://data/units/elves-wood/ElvishArcher.tscn")
-const Ranger := preload("res://data/units/elves-wood/ElvishRanger.tscn")
-const Scout := preload("res://data/units/elves-wood/Scout.tscn")
-
 const INCOME_PER_VILLAGE = 1 # How much gold extra each village provides
 
 const HEAL_ON_VILLAGE = 8 # Each unit starting its turn in a village heals this amount per turn
@@ -25,6 +21,8 @@ var leaders := []
 var viewable := {}
 
 var viewable_units := {} #dont know if we need this, but just in case
+
+export var faction := ""
 
 export(String, "Red", "Blue", "Green", "Purple", "Black", "White", "Brown", "Orange", "Teal") var team_color := "Red"
 export(String, "Standard", "Knalgan", "Long", "Ragged", "Undead", "Wood-Elvish") var flag_type := "Standard"
@@ -46,8 +44,6 @@ onready var number := get_index() + 1
 onready var units = $Units as Node2D
 onready var flags = $Flags as Node2D
 
-var recruitable_unit_type_scenes : Array
-
 func _ready() -> void:
 	Event.connect("turn_refresh", self, "_on_turn_refresh")
 
@@ -59,7 +55,7 @@ func _ready() -> void:
 
 	_calculate_upkeep()
 	_calculate_income()
-	recruitable_unit_type_scenes = [Archer, Ranger, Scout]
+	_initialize_faction_data()
 
 func add_unit(unit, is_leader := false) -> void:
 	"""
@@ -123,6 +119,10 @@ func _calculate_income() -> void:
 	The default calculation is 2 + 1 per village
 	"""
 	income = base_income + INCOME_PER_VILLAGE * villages.size()
+
+func _initialize_faction_data():
+	var factionResource = Registry.factions[faction]
+	recruit = factionResource.recruit
 
 func _turn_refresh(first_turn: bool) -> void:
 	"""


### PR DESCRIPTION
This PR brings some changes in area of recruitment. 
1) Now scenario config file has property sides with sides configured in dict. There is no separate side resource. Sides are no longer hardcoded and are loaded from that file dynamically.
2) Part of the side configuration is faction - all recruitable units of side are now taken from faction config.
3) Removed duplicated variable to hold recruitable units in `Side` class (did not notice previous one, it was unused anyways).
4) Now just string id of `unit_type` is passed around between recruitment popups and game. If needed actual `UnitType` object is taken from registry.
