### PR TITLE
Fixes typing issue in recruitment code

### DIFF
--- a/source/interface/hud/UnitRecruitmentCard.gd
+++ b/source/interface/hud/UnitRecruitmentCard.gd
@@ -9,7 +9,7 @@ var unit_type_id: String
 
 func initialize(unit_type_id: String) -> void:
 	self.unit_type_id = unit_type_id
-	var unit_type: PackedScene = Registry.units[unit_type_id].instance()
+	var unit_type := Registry.units[unit_type_id].instance() as UnitType
 	avatar.texture = unit_type.find_node("Sprite").texture
 	name_label.text = unit_type.name
 	cost_label.text = str(unit_type.cost)


### PR DESCRIPTION
wrong type was assigned to variable of type `PackedScene`, we were actually assigning `Node2D` there. Godot 3.2 actually checks that, previous version didn't

Fixes https://github.com/wesnoth/haldric/issues/115