### PR TITLE
Connect editor buttons to actions again after refactor

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -54,6 +54,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://source/unit/Defense.gd"
 }, {
+"base": "CanvasLayer",
+"class": "EditorHUD",
+"language": "GDScript",
+"path": "res://source/editor/EditorHUD.gd"
+}, {
 "base": "AStar",
 "class": "Grid",
 "language": "GDScript",
@@ -199,6 +204,7 @@ _global_script_class_icons={
 "CombatPlate": "",
 "Controller": "",
 "Defense": "",
+"EditorHUD": "",
 "Grid": "",
 "Hex": "",
 "Location": "",
@@ -259,7 +265,6 @@ Scene="*res://addons/scene_manager/source/Scene.tscn"
 gdscript/warnings/unassigned_variable=false
 gdscript/warnings/unassigned_variable_op_assign=false
 gdscript/warnings/unused_variable=false
-gdscript/warnings/unused_class_variable=false
 gdscript/warnings/unused_argument=false
 
 [display]

--- a/source/editor/Editor.gd
+++ b/source/editor/Editor.gd
@@ -14,9 +14,7 @@ onready var scenario_container := $ScenarioLayer/ViewportContainer/Viewport/Scen
 onready var camera := $ScenarioLayer/ViewportContainer/Viewport/Camera2D
 onready var scenario_viewport := $ScenarioLayer/ViewportContainer/Viewport as Viewport
 
-onready var HUD := $UI/HUD as CanvasLayer
-
-onready var line_edit := $UI/HUD/UIButtons/HBoxContainer/LineEdit as LineEdit
+onready var HUD := $UI/HUD as EditorHUD
 onready var minimap := $UI/HUD/Minimap as Control
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -37,6 +35,10 @@ func _ready() -> void:
 	minimap.connect("map_position_change_requested", self, "_on_map_position_change_requested")
 
 	current_clear_tile = scenario.map.default_tile
+
+	HUD.save_button.connect("button_down", self, "_on_save_button_down")
+	HUD.load_button.connect("button_down", self, "_on_load_button_down")
+	HUD.new_map_button.connect("button_down", self, "_on_new_map_button_down")
 
 func _update() -> void:
 	scenario.map.update_terrain()
@@ -120,6 +122,7 @@ func _save_map(scenario_name: String) -> void:
 	elif ResourceSaver.save(res_path, r_scenario) != OK:
 		print("Failed to save map resource", res_path)
 	else:
+		print("Saved scenario " + scenario_name)
 		Registry.register_scenario(id, r_scenario, scn_path)
 
 func _on_button_pressed(id: int) -> void:
@@ -129,13 +132,13 @@ func _on_button_pressed(id: int) -> void:
 	if Input.is_action_just_released("mouse_right"):
 		current_clear_tile = id
 
-func _on_Save_pressed() -> void:
-	_save_map(line_edit.text)
+func _on_save_button_down() -> void:
+	_save_map(HUD.get_map_name())
 
-func _on_Load_pressed() -> void:
-	_load_map(line_edit.text)
+func _on_load_button_down() -> void:
+	_load_map(HUD.get_map_name())
 
-func _on_New_pressed() -> void:
+func _on_new_map_button_down() -> void:
 	_new_map()
 
 func _on_map_position_change_requested(new_position: Vector2) -> void:

--- a/source/editor/EditorHUD.gd
+++ b/source/editor/EditorHUD.gd
@@ -1,7 +1,17 @@
 extends CanvasLayer
+class_name EditorHUD
 
 onready var container := $TileButtons/GridContainer as GridContainer
 onready var pause_menu := $PauseMenu
 
+onready var new_map_button := $UIButtons/HBoxContainer/NewMapButton as Button
+onready var save_button := $UIButtons/HBoxContainer/SaveButton as Button
+onready var load_button := $UIButtons/HBoxContainer/LoadMapButton as Button
+onready var _map_name_line_edit := $UIButtons/HBoxContainer/MapNameLineEdit as LineEdit
+
+
 func add_button(button: TextureButton) -> void:
 	container.add_child(button)
+
+func get_map_name() -> String:
+	return _map_name_line_edit.text

--- a/source/editor/EditorHUD.tscn
+++ b/source/editor/EditorHUD.tscn
@@ -74,14 +74,14 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="New" type="Button" parent="UIButtons/HBoxContainer"]
+[node name="NewMapButton" type="Button" parent="UIButtons/HBoxContainer"]
 margin_left = 69.0
 margin_right = 149.0
 margin_bottom = 69.0
 rect_min_size = Vector2( 80, 0 )
 text = "New"
 
-[node name="LineEdit" type="LineEdit" parent="UIButtons/HBoxContainer"]
+[node name="MapNameLineEdit" type="LineEdit" parent="UIButtons/HBoxContainer"]
 margin_left = 169.0
 margin_right = 329.0
 margin_bottom = 69.0
@@ -90,14 +90,14 @@ focus_mode = 1
 context_menu_enabled = false
 placeholder_text = "scenario name"
 
-[node name="Save" type="Button" parent="UIButtons/HBoxContainer"]
+[node name="SaveButton" type="Button" parent="UIButtons/HBoxContainer"]
 margin_left = 349.0
 margin_right = 429.0
 margin_bottom = 69.0
 rect_min_size = Vector2( 80, 0 )
 text = "Save"
 
-[node name="Load" type="Button" parent="UIButtons/HBoxContainer"]
+[node name="LoadMapButton" type="Button" parent="UIButtons/HBoxContainer"]
 margin_left = 449.0
 margin_right = 529.0
 margin_bottom = 69.0


### PR DESCRIPTION
After refactoring HUD signals from editor buttons were not connected - they were probably connected via scene config before. Here I connect them in code and do minor cleanup.
Saving and loading map is still broken but at least actions run as previously now.

I think that this PR proves that we should do connecting signals in code so that it is not lost during refactoring of scenes