### PR TITLE
Fix bug that sets (kill xp = killed unit's level * 8), instead adding

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -318,7 +318,7 @@ ui_accept={
 }
 toggle_fullscreen={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":true,"pressed":false,"scancode":70,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":true,"command":true,"pressed":false,"scancode":70,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777254,"unicode":0,"echo":false,"script":null)
  ]
 }

--- a/source/unit/Unit.gd
+++ b/source/unit/Unit.gd
@@ -100,7 +100,7 @@ func kill(active_side: bool, attacker: Unit) -> void:
 	if attacker.side.viewable_units.has(attacker):
 		attacker.side.viewable_units.erase(attacker)
 	attacker.set_reachable()
-	attacker.experience_current = type.level * 8
+	attacker.experience_current += type.level * 8
 	emit_signal("died", self)
 
 func get_movement_cost(loc: Location) -> int:


### PR DESCRIPTION
Instead of the line on line 103:
`	attacker.experience_current = type.level * 8`
which sets (kill xp = killed unit's level * 8), and makes it impossible to level up.
I replaced it with 
`	attacker.experience_current += type.level * 8`