### PR TITLE
Decouple unit UI from unit

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -185,6 +185,11 @@ _global_script_classes=[ {
 "path": "res://source/unit/Unit.gd"
 }, {
 "base": "Node2D",
+"class": "UnitPlate",
+"language": "GDScript",
+"path": "res://source/interface/hud/UnitPlate.gd"
+}, {
+"base": "Node2D",
 "class": "UnitType",
 "language": "GDScript",
 "path": "res://source/unit/UnitType.gd"
@@ -230,6 +235,7 @@ _global_script_class_icons={
 "ToDWheel": "",
 "Transitions": "",
 "Unit": "",
+"UnitPlate": "",
 "UnitType": "",
 "WeaponSpecial": ""
 }

--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -1,5 +1,6 @@
 extends Node2D
 
+
 var schedule := []
 
 var scenario: Scenario = null
@@ -13,10 +14,10 @@ var unit_type_to_recruit : String
 
 onready var tween = $Tween
 
-onready var UI := $UI as CanvasLayer
-onready var HUD := $UI/HUD as CanvasLayer
+onready var UI := $ScenarioLayer/ViewportContainer/Viewport/UI as CanvasLayer
 
-onready var minimap := $UI/HUD/Minimap
+onready var HUD := $HUD as CanvasLayer
+onready var minimap := $HUD/Minimap
 
 onready var draw := $ScenarioLayer/ViewportContainer/Viewport/Draw as Node2D
 onready var viewport_container := $ScenarioLayer/ViewportContainer as ViewportContainer
@@ -127,6 +128,9 @@ func _load_scenario() -> void:
 
 	scenario_placeholder.replace_by(scenario)
 	scenario.map.map_data = Global.state.scenario.data.map_data
+	# this has to happen before initialization since we need to react to units
+	# that are added to scenario at initialization
+	scenario.connect("unit_added", self, "_on_new_unit_added")
 	scenario.initialize()
 
 	#warning-ignore:return_value_discarded
@@ -135,9 +139,11 @@ func _load_scenario() -> void:
 	scenario.connect("unit_moved", self, "_on_unit_moved")
 	#warning-ignore:return_value_discarded
 	scenario.connect("unit_move_finished", self, "_on_unit_move_finished")
-
 	draw.map_area = scenario.map.get_pixel_size()
-
+	
+func _on_new_unit_added(unit):
+	UI.add_unit_plate(unit)
+	
 # used in map for workaround on nested viewports issue
 func get_camera_zoom() -> Vector2:
 	return camera.zoom

--- a/source/game/Game.tscn
+++ b/source/game/Game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://source/game/Game.gd" type="Script" id=1]
 [ext_resource path="res://source/scenario/OffMap.tscn" type="PackedScene" id=2]
@@ -6,10 +6,13 @@
 [ext_resource path="res://source/interface/draw/Draw.tscn" type="PackedScene" id=4]
 [ext_resource path="res://source/camera/WesnothCamera.tscn" type="PackedScene" id=5]
 [ext_resource path="res://source/game/ui/GameUI.tscn" type="PackedScene" id=6]
+[ext_resource path="res://source/interface/hud/GameHUD.tscn" type="PackedScene" id=7]
 
 [sub_resource type="ShaderMaterial" id=1]
 shader = ExtResource( 3 )
 shader_param/delta = null
+
+[sub_resource type="World2D" id=2]
 
 [node name="Game" type="Node2D"]
 script = ExtResource( 1 )
@@ -34,6 +37,7 @@ __meta__ = {
 
 [node name="Viewport" type="Viewport" parent="ScenarioLayer/ViewportContainer"]
 size = Vector2( 1920, 1080 )
+world_2d = SubResource( 2 )
 transparent_bg = true
 handle_input_locally = false
 hdr = false
@@ -51,4 +55,6 @@ render_target_update_mode = 3
 z_index = 20
 copy_mode = 2
 
-[node name="UI" parent="." instance=ExtResource( 6 )]
+[node name="UI" parent="ScenarioLayer/ViewportContainer/Viewport" instance=ExtResource( 6 )]
+
+[node name="HUD" parent="." instance=ExtResource( 7 )]

--- a/source/game/ui/GameUI.gd
+++ b/source/game/ui/GameUI.gd
@@ -1,6 +1,17 @@
 extends CanvasLayer
-
+const UnitPlate = preload("res://source/interface/hud/UnitPlate.tscn")
 onready var unit_plate_container := $UnitPlateContainer as Control
 
-func add_unit_plate(unit_plate) -> void:
+var unit_plates := {}
+
+func add_unit_plate(unit: Unit) -> void:
+	var unit_plate = UnitPlate.instance() as UnitPlate
 	unit_plate_container.add_child(unit_plate)
+	unit_plate.init(unit)
+	unit.attach_ui(unit_plate)
+	unit_plates[unit.get_instance_id()] = unit_plate
+
+func remove_unit_plate(unit: Unit) -> void:
+	var plate_to_remove = unit_plates[unit.get_instance_id()]
+	unit_plates.erase(unit.get_instance_id())
+	unit_plate_container.remove_child(plate_to_remove)

--- a/source/game/ui/GameUI.tscn
+++ b/source/game/ui/GameUI.tscn
@@ -1,12 +1,15 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://source/game/ui/GameUI.gd" type="Script" id=1]
-[ext_resource path="res://source/interface/hud/GameHUD.tscn" type="PackedScene" id=2]
 
-[node name="UI" type="CanvasLayer"]
+[node name="UI" type="CanvasLayer" groups=[
+"UI",
+]]
+follow_viewport_enable = true
 script = ExtResource( 1 )
 
 [node name="UnitPlateContainer" type="Control" parent="."]
 mouse_filter = 2
-
-[node name="HUD" parent="." instance=ExtResource( 2 )]
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/source/interface/hud/AttackPopup.tscn
+++ b/source/interface/hud/AttackPopup.tscn
@@ -4,7 +4,6 @@
 [ext_resource path="res://graphics/styles/panel.tres" type="StyleBox" id=2]
 
 [node name="AttackPopup" type="PopupPanel"]
-visible = true
 margin_right = 129.0
 margin_bottom = 57.0
 size_flags_vertical = 5

--- a/source/interface/hud/UnitPlate.gd
+++ b/source/interface/hud/UnitPlate.gd
@@ -1,0 +1,28 @@
+extends Node2D
+class_name UnitPlate
+
+onready var state_label = $StateLabel as Label
+onready var life_bar = $LifeBar
+
+func init(unit):
+	unit.connect("state_changed", self, "_on_unit_state_changed")
+	unit.connect("health_changed", self, "_on_unit_health_changed")
+	unit.connect("hide", self, "_on_unit_hidden")
+	unit.connect("unhide", self, "_on_unit_unhidden")
+	
+	# set initial values
+	_on_unit_state_changed(unit.current_state.name)
+	_on_unit_health_changed(unit)
+	visible = unit.visible
+	
+func _on_unit_state_changed(new_state):
+	state_label.text = new_state
+
+func _on_unit_health_changed(unit):
+	life_bar.update_unit(unit)
+
+func _on_unit_hidden():
+	visible = false
+
+func _on_unit_unhidden():
+	visible = true

--- a/source/interface/hud/UnitPlate.tscn
+++ b/source/interface/hud/UnitPlate.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://source/interface/hud/UnitPlate.gd" type="Script" id=1]
+[ext_resource path="res://graphics/fonts/Lato12.tres" type="DynamicFont" id=2]
+[ext_resource path="res://source/interface/hud/LifeBar.tscn" type="PackedScene" id=3]
+
+[node name="UnitPlate" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="StateLabel" type="Label" parent="."]
+visible = false
+margin_left = -20.0
+margin_top = 30.0
+margin_right = 20.0
+margin_bottom = 45.0
+custom_fonts/font = ExtResource( 2 )
+text = "idle"
+align = 1
+valign = 1
+
+[node name="LifeBar" parent="." instance=ExtResource( 3 )]
+margin_left = -20.0
+margin_top = -40.0
+margin_right = 20.0
+margin_bottom = -33.0

--- a/source/scenario/Scenario.gd
+++ b/source/scenario/Scenario.gd
@@ -6,6 +6,7 @@ const Map = preload("res://source/scenario/map/Map.tscn")
 signal unit_experienced(unit)
 signal unit_moved(unit, location)
 signal unit_move_finished(unit, location)
+signal unit_added(unit)
 
 var turn := 0
 var turns := -1
@@ -42,6 +43,7 @@ func add_unit_with_loaded_data(side: Side, unit_type: UnitType, target_location 
 
 	side.add_unit(unit, is_leader)
 	unit.place_at(target_location)
+	emit_signal("unit_added", unit)
 
 func add_unit(side_number: int, unit_id: String, x: int, y: int, is_leader := false) -> void:
 	var unit_type: PackedScene = Registry.units[unit_id]

--- a/source/unit/Unit.tscn
+++ b/source/unit/Unit.tscn
@@ -1,11 +1,9 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://source/unit/Unit.gd" type="Script" id=1]
 [ext_resource path="res://source/unit/states/Idle.gd" type="Script" id=2]
 [ext_resource path="res://source/unit/states/Move.gd" type="Script" id=3]
 [ext_resource path="res://source/unit/states/Attack.gd" type="Script" id=4]
-[ext_resource path="res://graphics/fonts/Lato12.tres" type="DynamicFont" id=5]
-[ext_resource path="res://source/interface/hud/LifeBar.tscn" type="PackedScene" id=6]
 
 [node name="Unit" type="Node2D" groups=[
 "Unit",
@@ -25,20 +23,5 @@ script = ExtResource( 3 )
 [node name="Attack" type="Node" parent="States"]
 script = ExtResource( 4 )
 
-[node name="StateLabel" type="Label" parent="."]
-visible = false
-margin_left = -20.0
-margin_top = 30.0
-margin_right = 20.0
-margin_bottom = 45.0
-custom_fonts/font = ExtResource( 5 )
-text = "idle"
-align = 1
-valign = 1
-
-[node name="LifeBar" parent="." instance=ExtResource( 6 )]
-margin_left = -20.0
-margin_top = -40.0
-margin_right = 20.0
-margin_bottom = -37.0
+[node name="UnitHUDTransform" type="RemoteTransform2D" parent="."]
 [connection signal="tween_completed" from="Tween" to="States/Move" method="_on_Tween_tween_completed"]


### PR DESCRIPTION
1. as requested in https://github.com/wesnoth/haldric/issues/67 `UnitPlate` is now separate node managed by `GameUI`
2. `Unit` has remote transform that allows `UnitPlate` to follow moving `Unit`
3. `Unit` communicates with `UnitPlate` only with signals. They only know about each other through remote transform and during initialization (to wire-up signals and set transform reference)
4. `GameHUD` and `GameUI` have been splitted, there was an issue when HUD was attempting to draw viewport it was part of in separate viewports (minimap, unit view)