### PR TITLE
Validate map size before enabling creation

### DIFF
--- a/source/interface/editor/EditorUI.gd
+++ b/source/interface/editor/EditorUI.gd
@@ -72,9 +72,11 @@ func highlight(button: Button) -> void:
 	tween.start()
 
 func validate_create_button() -> void:
+	print(width_value)
+	print(height_value)
 	if width_value > 0 and height_value > 0 and create_button.disabled:
 		create_button.disabled = false
-	elif not create_button.disabled:
+	elif not create_button.disabled and width_value <= 0 or height_value <= 0:
 		create_button.disabled = true
 
 func _on_player_mode_selected() -> void:
@@ -120,3 +122,4 @@ func _on_MapWidthInput_text_changed(new_text):
 func _on_MapHeightInput_text_changed(new_text):
 	height_value = int(new_text)
 	validate_create_button()
+

--- a/source/interface/editor/EditorUI.gd
+++ b/source/interface/editor/EditorUI.gd
@@ -25,6 +25,10 @@ onready var save_edit := $HUD/PanelContainer/VBoxContainer/Save/LineEdit
 onready var width_edit := $HUD/PanelContainer/VBoxContainer/NewMap/Width/LineEdit
 onready var height_edit := $HUD/PanelContainer/VBoxContainer/NewMap/Height/LineEdit
 
+onready var create_button := $HUD/PanelContainer/VBoxContainer/NewMap/Button
+
+var width_value: int
+var height_value: int
 
 func _ready() -> void:
 	_add_mode_button("Terrain", "_on_terrain_mode_selected")
@@ -67,6 +71,11 @@ func highlight(button: Button) -> void:
 	tween.interpolate_property(terrain_selector, "rect_size", terrain_selector.rect_size, button.rect_size, 0.25, Tween.TRANS_SINE, Tween.EASE_IN_OUT)
 	tween.start()
 
+func validate_create_button() -> void:
+	if width_value > 0 and height_value > 0 and create_button.disabled:
+		create_button.disabled = false
+	elif not create_button.disabled:
+		create_button.disabled = true
 
 func _on_player_mode_selected() -> void:
 	emit_signal("mode_changed", MapEditor.PaintMode.PLAYER)
@@ -103,3 +112,11 @@ func _on_NewMap_pressed() -> void:
 
 func _on_Quit_pressed() -> void:
 	Scene.change("TitleScreen")
+
+func _on_MapWidthInput_text_changed(new_text):
+	width_value = int(new_text)
+	validate_create_button()
+
+func _on_MapHeightInput_text_changed(new_text):
+	height_value = int(new_text)
+	validate_create_button()

--- a/source/interface/editor/EditorUI.tscn
+++ b/source/interface/editor/EditorUI.tscn
@@ -31,7 +31,7 @@ __meta__ = {
 margin_left = 7.0
 margin_top = 7.0
 margin_right = 293.0
-margin_bottom = 384.0
+margin_bottom = 365.0
 
 [node name="ModeButtons" type="HBoxContainer" parent="HUD/PanelContainer/VBoxContainer"]
 margin_right = 286.0
@@ -149,6 +149,7 @@ margin_right = 286.0
 margin_bottom = 96.0
 rect_min_size = Vector2( 0, 40 )
 focus_mode = 0
+disabled = true
 enabled_focus_mode = 0
 text = "New Map"
 
@@ -217,6 +218,8 @@ __meta__ = {
 }
 [connection signal="value_changed" from="HUD/PanelContainer/VBoxContainer/PlayerSlider" to="." method="_on_PlayerSlider_value_changed"]
 [connection signal="value_changed" from="HUD/PanelContainer/VBoxContainer/BrushSizeSlider" to="." method="_on_BrushSizeSlider_value_changed"]
+[connection signal="text_changed" from="HUD/PanelContainer/VBoxContainer/NewMap/Width/LineEdit" to="." method="_on_MapWidthInput_text_changed"]
+[connection signal="text_changed" from="HUD/PanelContainer/VBoxContainer/NewMap/Height/LineEdit" to="." method="_on_MapHeightInput_text_changed"]
 [connection signal="pressed" from="HUD/PanelContainer/VBoxContainer/NewMap/Button" to="." method="_on_NewMap_pressed"]
 [connection signal="pressed" from="HUD/PanelContainer/VBoxContainer/Save/Save" to="." method="_on_Save_pressed"]
 [connection signal="pressed" from="HUD/PanelContainer/VBoxContainer/Quit" to="." method="_on_Quit_pressed"]


### PR DESCRIPTION
Simple update made to prevent crashes and get familiarized with the project architecture before making further contributions.

![Peek 2020-11-25 15-30](https://user-images.githubusercontent.com/28108272/100282770-f89c2480-2f4a-11eb-8368-7469be6b58e1.gif)

I'm willing to add also a dialog to save and load map files onto the editor once I have time. Let me know of any changes needed in this PR.