### PR TITLE
refresh units on turn end, makes movement visible for other sides too

### DIFF
--- a/data/scenarios/MiniScenario2.tscn
+++ b/data/scenarios/MiniScenario2.tscn
@@ -15,7 +15,7 @@
 
 [node name="TestScenario" type="Node2D"]
 script = ExtResource( 1 )
-next_scenario = "MiniScenario2"
+next_scenario = "MiniScenario"
 
 [node name="Schedule" type="Node" parent="."]
 script = ExtResource( 4 )
@@ -98,6 +98,7 @@ recruit = [ "Bowman", "Mage", "Horseman", "Cavalryman", "Spearman" ]
 [node name="Side2" type="Node" parent="Sides"]
 script = ExtResource( 2 )
 number = 2
+controller = 1
 start_position = Vector2( 15, 12 )
 color = Color( 0.044534, 0.0379333, 0.882813, 1 )
 ai = "ActionAI"

--- a/data/scenarios/mini_scenario2.tres
+++ b/data/scenarios/mini_scenario2.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" load_steps=4 format=2]
+
+[ext_resource path="res://source/data/ScenarioData.gd" type="Script" id=1]
+[ext_resource path="res://data/maps/map.tres" type="Resource" id=2]
+[ext_resource path="res://data/scenarios/MiniScenario2.tscn" type="PackedScene" id=3]
+
+[resource]
+script = ExtResource( 1 )
+id = "MiniScenario2"
+alias = "Mini Scenario2"
+scene = ExtResource( 3 )
+map = ExtResource( 2 )

--- a/project.godot
+++ b/project.godot
@@ -654,7 +654,7 @@ MMB={
 }
 recruit={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":true,"pressed":false,"scancode":82,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":true,"command":true,"pressed":false,"scancode":82,"unicode":0,"echo":false,"script":null)
  ]
 }
 recall={
@@ -669,7 +669,7 @@ move={
 }
 end_turn={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":true,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":true,"command":true,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
  ]
 }
 message={
@@ -684,7 +684,7 @@ edit_base_only={
 }
 toggle_fullscreen={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":true,"pressed":false,"scancode":70,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":true,"command":true,"pressed":false,"scancode":70,"unicode":0,"echo":false,"script":null)
  ]
 }
 

--- a/source/game/Game.gd
+++ b/source/game/Game.gd
@@ -18,6 +18,9 @@ func _ready() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 
+	if scenario.current_side.controller == Side.Controller.AI:
+		return
+
 	if event.is_action_released("RMB"):
 		if selected_skill:
 			_set_selected_skill(null)

--- a/source/interface/game/UnitPlate.tscn
+++ b/source/interface/game/UnitPlate.tscn
@@ -3,7 +3,6 @@
 [ext_resource path="res://source/interface/game/UnitPlate.gd" type="Script" id=1]
 [ext_resource path="res://graphics/images/interface/white.png" type="Texture" id=2]
 
-
 [node name="UnitPlate" type="Node2D"]
 script = ExtResource( 1 )
 

--- a/source/interface/game/UnitUI.tscn
+++ b/source/interface/game/UnitUI.tscn
@@ -2,7 +2,6 @@
 
 [ext_resource path="res://source/interface/game/UnitUI.gd" type="Script" id=1]
 
-
 [node name="UnitUI" type="Control" groups=[
 "UnitUI",
 ]]

--- a/source/menu/TitleScreen.tscn
+++ b/source/menu/TitleScreen.tscn
@@ -46,7 +46,6 @@ margin_bottom = 188.0
 rect_min_size = Vector2( 200, 60 )
 custom_fonts/font = ExtResource( 2 )
 text = "QUIT"
-
 [connection signal="pressed" from="CenterContainer/VBoxContainer/Play" to="." method="_on_Play_pressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/Editor" to="." method="_on_Editor_pressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/Quit" to="." method="_on_Quit_pressed"]

--- a/source/scenario/Scenario.gd
+++ b/source/scenario/Scenario.gd
@@ -1,4 +1,4 @@
-tool
+source/unit/Unit.gdtool
 extends Node2D
 class_name Scenario
 
@@ -453,9 +453,8 @@ func _check_victory_conditions() -> void:
 	var victory := true
 
 	for side in get_sides():
-		if not side == current_side:
-			if side.leaders:
-				victory = false
+		if side.leaders:
+			victory = false
 
 	if victory:
 		Console.write("Side %d won!" % current_side.number)

--- a/source/scenario/Scenario.gd
+++ b/source/scenario/Scenario.gd
@@ -460,11 +460,10 @@ func _check_victory_conditions() -> void:
 
 	if victory:
 		Console.write("Side %d won!" % current_side.number)
-		
+
 		if (next_scenario):
 			Global.selected_scenario = Data.scenarios[next_scenario]
-			Console.write("CHANGING SCENARIO")
-		Console.write("VICOTRY!")
+
 		Scene.change("Game")
 
 

--- a/source/scenario/Scenario.gd
+++ b/source/scenario/Scenario.gd
@@ -1,4 +1,4 @@
-source/unit/Unit.gdtool
+tool
 extends Node2D
 class_name Scenario
 

--- a/source/scenario/Scenario.gd
+++ b/source/scenario/Scenario.gd
@@ -28,6 +28,8 @@ onready var map_container := Node2D.new()
 onready var flag_container := YSort.new()
 onready var unit_container := YSort.new()
 
+export (String) var next_scenario := "";
+
 
 func _ready() -> void:
 	if Engine.editor_hint:
@@ -450,15 +452,20 @@ func _grab_castle(loc: Location) -> void:
 
 
 func _check_victory_conditions() -> void:
-	var victory := true
+	var victory := false
 
 	for side in get_sides():
-		if side.leaders:
-			victory = false
+		if not side.leaders:
+			victory = true
 
 	if victory:
 		Console.write("Side %d won!" % current_side.number)
-		get_tree().reload_current_scene()
+		
+		if (next_scenario):
+			Global.selected_scenario = Data.scenarios[next_scenario]
+			Console.write("CHANGING SCENARIO")
+		Console.write("VICOTRY!")
+		Scene.change("Game")
 
 
 func _on_combat_finished() -> void:

--- a/source/unit/Unit.gd
+++ b/source/unit/Unit.gd
@@ -124,9 +124,6 @@ func refresh() -> void:
 		heal(heal_on_refresh)
 		heal_on_refresh = 0
 
-	actions.fill()
-	moves.fill()
-
 
 func grant_experience(amount: int) -> void:
 	experience.value += amount
@@ -151,6 +148,9 @@ func grant_experience(amount: int) -> void:
 
 func turn_end() -> void:
 	emit_signal("turn_end")
+
+	actions.fill()
+	moves.fill()
 
 
 func reset() -> void:


### PR DESCRIPTION
Previously, movement was not visible for other sides if the previous player already ended their turn. This PR refreshes units at the end of their turn.